### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, trunk ]


### PR DESCRIPTION
Potential fix for [https://github.com/thesampaton/durable-streams-rust-server/security/code-scanning/2](https://github.com/thesampaton/durable-streams-rust-server/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block limiting the `GITHUB_TOKEN` to the minimal scope needed. For build/test-only workflows that just need to read code, `contents: read` is usually sufficient. This can be set at the workflow root so it applies to all jobs, unless a specific job needs broader permissions.

For this workflow, none of the shown jobs (`lint-fmt`, `test`, `conformance`) perform write operations on the repository or call GitHub APIs that require more than read access. Therefore, the best minimal change is to add a root-level `permissions` block near the top of `.github/workflows/ci.yml`, setting `contents: read`. This will cover the `test` job (and all others) and satisfy CodeQL while preserving current behavior. No changes are needed to individual jobs or steps.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a `permissions:` block after the `name: CI` line (line 1) and before the `on:` block (line 3).
- Set `contents: read` within that block.
- No new imports, methods, or other definitions are required, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
