### PR TITLE
Atomic create-with-data to fix TOCTOU races in PUT

### DIFF
--- a/src/handlers/put.rs
+++ b/src/handlers/put.rs
@@ -1,7 +1,7 @@
 use crate::protocol::error::{Error, Result};
 use crate::protocol::headers::{self, names};
 use crate::protocol::json_mode;
-use crate::storage::{CreateStreamResult, Storage, StreamConfig};
+use crate::storage::{CreateStreamResult, CreateWithDataResult, Storage, StreamConfig};
 use axum::{
     body::Body,
     extract::{Path, State},
@@ -105,41 +105,27 @@ pub async fn create_stream<S: Storage>(
         config = config.with_created_closed(true);
     }
 
-    // Create stream (returns created-vs-existing status atomically)
-    // Note: create_stream stores config for idempotent checks but does NOT
-    // set the closed flag — the handler closes explicitly after any appends.
-    let create_result = match storage.create_stream(&name, config) {
-        Ok(result) => result,
-        Err(Error::ConfigMismatch) => {
-            return Err(Error::ConfigMismatch);
-        }
-        Err(e) => return Err(e),
+    // Parse body into messages BEFORE creating the stream so that
+    // failures (e.g. invalid JSON) never leave an orphaned stream.
+    let messages = if body_bytes.is_empty() {
+        vec![]
+    } else if json_mode::is_json_content_type(&normalized_ct) {
+        // Empty JSON arrays produce no messages — that's fine for PUT
+        json_mode::process_append(&body_bytes)?
+    } else {
+        vec![body_bytes]
     };
-    let is_new = matches!(create_result, CreateStreamResult::Created);
 
-    // If new stream and body is non-empty, append initial data
-    if is_new && !body_bytes.is_empty() {
-        let messages = if json_mode::is_json_content_type(&normalized_ct) {
-            // Empty JSON arrays produce no messages — that's fine for PUT
-            json_mode::process_append(&body_bytes)?
-        } else {
-            vec![body_bytes]
-        };
+    // Atomic create + append + close. If commit_messages fails (e.g.
+    // memory limit), the stream is never inserted. If created_closed,
+    // the entry is closed before it becomes visible to other operations.
+    let CreateWithDataResult {
+        status: create_status,
+        next_offset,
+        closed,
+    } = storage.create_stream_with_data(&name, config, messages, created_closed)?;
 
-        if !messages.is_empty() {
-            storage.batch_append(&name, messages, &normalized_ct, None)?;
-        }
-    }
-
-    // Close stream after appending data (if created_closed)
-    if is_new && created_closed {
-        storage.close_stream(&name)?;
-    }
-
-    // Get metadata for response headers (snapshot after any appends)
-    let metadata = storage.head(&name)?;
-
-    let status = if is_new {
+    let status = if matches!(create_status, CreateStreamResult::Created) {
         StatusCode::CREATED
     } else {
         StatusCode::OK
@@ -152,11 +138,11 @@ pub async fn create_stream<S: Storage>(
     response_headers.insert("content-type", normalized_ct.parse().unwrap());
     response_headers.insert(
         names::STREAM_NEXT_OFFSET,
-        metadata.next_offset.to_string().parse().unwrap(),
+        next_offset.to_string().parse().unwrap(),
     );
     response_headers.insert("location", location.parse().unwrap());
 
-    if metadata.closed {
+    if closed {
         response_headers.insert(names::STREAM_CLOSED, "true".parse().unwrap());
     }
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -584,6 +584,66 @@ impl Storage for InMemoryStorage {
         })
     }
 
+    fn create_stream_with_data(
+        &self,
+        name: &str,
+        config: StreamConfig,
+        messages: Vec<Bytes>,
+        should_close: bool,
+    ) -> Result<super::CreateWithDataResult> {
+        let mut streams = self.streams.write().expect("streams lock poisoned");
+
+        if let Some(stream_arc) = streams.get(name) {
+            let stream = stream_arc.read().expect("stream lock poisoned");
+
+            if Self::is_expired(&stream) {
+                // Expired — reclaim memory, then fall through to create new
+                let stream_bytes = stream.total_bytes;
+                drop(stream);
+                streams.remove(name);
+                let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+                *total = total.saturating_sub(stream_bytes);
+                drop(total);
+            } else if stream.config == config {
+                // Idempotent create — return existing state, ignore body/close
+                let next_offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
+                let closed = stream.closed;
+                return Ok(super::CreateWithDataResult {
+                    status: CreateStreamResult::AlreadyExists,
+                    next_offset,
+                    closed,
+                });
+            } else {
+                return Err(Error::ConfigMismatch);
+            }
+        }
+
+        // Build entry in memory (not yet in the map)
+        let mut entry = StreamEntry::new(config);
+
+        // Append initial data — if this fails the entry is never inserted
+        if !messages.is_empty() {
+            self.commit_messages(&mut entry, messages)?;
+        }
+
+        // Close atomically with creation
+        if should_close {
+            entry.closed = true;
+        }
+
+        // Snapshot state before inserting
+        let next_offset = Offset::new(entry.next_read_seq, entry.next_byte_offset);
+        let closed = entry.closed;
+
+        streams.insert(name.to_string(), Arc::new(RwLock::new(entry)));
+
+        Ok(super::CreateWithDataResult {
+            status: CreateStreamResult::Created,
+            next_offset,
+            closed,
+        })
+    }
+
     fn exists(&self, name: &str) -> bool {
         let streams = self.streams.read().expect("streams lock poisoned");
         if let Some(stream_arc) = streams.get(name) {
@@ -890,6 +950,83 @@ mod tests {
             matches!(retry, Ok(ProducerAppendResult::Accepted { .. })),
             "retry with same producer seq and stream seq should succeed"
         );
+    }
+
+    #[test]
+    fn test_create_with_data_rolls_back_on_memory_limit() {
+        // P1: if commit_messages fails, the stream must not exist
+        let storage = InMemoryStorage::new(1024, 8);
+        let config = StreamConfig::new("text/plain".to_string());
+        let oversized = vec![Bytes::from(vec![0_u8; 9])];
+
+        let err = storage.create_stream_with_data("test", config, oversized, false);
+        assert!(matches!(err, Err(Error::StreamSizeLimitExceeded)));
+        assert!(
+            !storage.exists("test"),
+            "stream must not exist after failed create"
+        );
+    }
+
+    #[test]
+    fn test_create_with_data_closed_is_atomic() {
+        // P2: created_closed must be set before the entry is visible
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string()).with_created_closed(true);
+
+        let result = storage
+            .create_stream_with_data("test", config, vec![], true)
+            .unwrap();
+        assert_eq!(result.status, CreateStreamResult::Created);
+        assert!(result.closed, "stream must be closed in result snapshot");
+
+        // Verify via head() as well
+        let meta = storage.head("test").unwrap();
+        assert!(meta.closed, "stream must be closed via head()");
+
+        // Appends must be rejected
+        assert!(matches!(
+            storage.append("test", Bytes::from("data"), "text/plain"),
+            Err(Error::StreamClosed)
+        ));
+    }
+
+    #[test]
+    fn test_create_with_data_appends_and_closes() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string()).with_created_closed(true);
+        let messages = vec![Bytes::from("hello"), Bytes::from("world")];
+
+        let result = storage
+            .create_stream_with_data("test", config, messages, true)
+            .unwrap();
+        assert_eq!(result.status, CreateStreamResult::Created);
+        assert!(result.closed);
+
+        let meta = storage.head("test").unwrap();
+        assert_eq!(meta.message_count, 2);
+        assert!(meta.closed);
+    }
+
+    #[test]
+    fn test_create_with_data_idempotent_ignores_body() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+
+        // First create with data
+        let r1 = storage
+            .create_stream_with_data("test", config.clone(), vec![Bytes::from("a")], false)
+            .unwrap();
+        assert_eq!(r1.status, CreateStreamResult::Created);
+
+        // Idempotent recreate — body must be ignored
+        let r2 = storage
+            .create_stream_with_data("test", config, vec![Bytes::from("b")], false)
+            .unwrap();
+        assert_eq!(r2.status, CreateStreamResult::AlreadyExists);
+
+        // Only 1 message from first create
+        let meta = storage.head("test").unwrap();
+        assert_eq!(meta.message_count, 1);
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -139,6 +139,20 @@ pub enum CreateStreamResult {
     AlreadyExists,
 }
 
+/// Result of atomic create-with-data operation.
+///
+/// Bundles creation status with a metadata snapshot taken under the
+/// same lock hold so the handler never needs a separate `head()` call.
+#[derive(Debug)]
+pub struct CreateWithDataResult {
+    /// Whether the stream was newly created or already existed.
+    pub status: CreateStreamResult,
+    /// Next offset (for `Stream-Next-Offset` response header).
+    pub next_offset: Offset,
+    /// Whether the stream is closed (for `Stream-Closed` response header).
+    pub closed: bool,
+}
+
 /// Result of an append with producer sequencing.
 ///
 /// Includes a snapshot of stream state taken atomically with the operation
@@ -256,6 +270,23 @@ pub trait Storage: Send + Sync {
         should_close: bool,
         seq: Option<&str>,
     ) -> Result<ProducerAppendResult>;
+
+    /// Atomically create a stream with optional initial data and close.
+    ///
+    /// Creates the stream, appends `messages` (if non-empty), and closes
+    /// (if `should_close`) — all before the entry becomes visible to other
+    /// operations. If `commit_messages` fails (e.g. memory limit), the
+    /// stream is never created.
+    ///
+    /// For idempotent recreates (`AlreadyExists`), the body and close
+    /// flag are ignored and existing metadata is returned.
+    fn create_stream_with_data(
+        &self,
+        name: &str,
+        config: StreamConfig,
+        messages: Vec<Bytes>,
+        should_close: bool,
+    ) -> Result<CreateWithDataResult>;
 
     /// Check if a stream exists
     fn exists(&self, name: &str) -> bool;


### PR DESCRIPTION
## Summary

- Replaces 4 separate storage calls in the PUT handler (create, append, close, head) with a single atomic `create_stream_with_data()` operation
- Builds the stream entry in memory, appends data, and sets closed state before inserting into the map — all under one lock hold
- Failed appends (e.g. memory limit) now roll back cleanly: the stream is never created
- Response metadata comes from the same snapshot, eliminating a TOCTOU race from the separate `head()` call

## Test plan

- [x] All 225 cargo tests pass (94 unit + 131 integration)
- [x] All 239 conformance tests pass
- [x] Clippy clean, formatting clean
- [x] 4 new unit tests covering rollback, atomic close, append+close, and idempotent recreate