### PR TITLE
Simplify conformance badge to use built-in workflow status

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -103,37 +103,3 @@ jobs:
         with:
           name: conformance-results
           path: /tmp/conformance-run/results.json
-
-  update-badge:
-    name: Update Conformance Badge
-    needs: conformance
-    if: github.ref == 'refs/heads/trunk' && always()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: badges
-
-      - name: Download test results
-        uses: actions/download-artifact@v4
-        with:
-          name: conformance-results
-
-      - name: Generate and push badge
-        run: |
-          if [ -f results.json ]; then
-            PASSED=$(jq '.numPassedTests' results.json)
-            TOTAL=$(jq '.numTotalTests' results.json)
-            FAILED=$(jq '.numFailedTests' results.json)
-            if [ "$FAILED" = "0" ]; then COLOR="brightgreen"; else COLOR="red"; fi
-            echo "{\"schemaVersion\":1,\"label\":\"conformance\",\"message\":\"${PASSED}/${TOTAL}\",\"color\":\"${COLOR}\"}" > conformance.json
-          else
-            echo "{\"schemaVersion\":1,\"label\":\"conformance\",\"message\":\"error\",\"color\":\"red\"}" > conformance.json
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add conformance.json
-          git diff --cached --quiet || git commit -m "Update conformance badge [skip ci]"
-          git push

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # durable-streams-rust-server
 
 [![CI](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml)
-[![Conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fthesampaton%2Fdurable-streams-rust-server%2Fbadges%2Fconformance.json)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml)
+[![Conformance](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml)
 
 Reference implementation of the [durable streams protocol](https://github.com/durable-streams/durable-streams), built on [Electric SQL](https://electric-sql.com/).
 
@@ -26,7 +26,7 @@ cargo fmt            # format
 
 This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.1`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md).
 
-Run conformance tests locally (see `/private/tmp/conformance-run` for a working setup):
+Run conformance tests locally:
 
 ```bash
 LONG_POLL_TIMEOUT_SECS=2 SSE_IDLE_CLOSE_SECS=5 cargo run &


### PR DESCRIPTION
## Summary
- Removed the `update-badge` job from the conformance workflow (required a non-existent `badges` branch, causing CI failures)
- Switched the README badge to GitHub's native workflow status badge
- Removed local path reference (`/private/tmp/conformance-run`) from README

## Test plan
- [ ] Verify conformance workflow runs without the `update-badge` job failing
- [ ] Verify README badge renders correctly on trunk