### PR TITLE
Remove redundant push-to-trunk CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches: [ trunk ]
   pull_request:
     branches: [ trunk ]
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,8 +1,6 @@
 name: Conformance
 
 on:
-  push:
-    branches: [ trunk ]
   pull_request:
     branches: [ trunk ]
 


### PR DESCRIPTION
## Summary
- Remove `push: branches: [trunk]` triggers from both `ci.yml` and `conformance.yml`
- Branch protection ruleset now requires all 5 status checks to pass on PRs before merge, making post-merge CI runs redundant

## Test plan
- [ ] Verify CI runs on this PR (confirming `pull_request` trigger still works)
- [ ] After merge, confirm no CI run is triggered by the push to trunk