### PR TITLE
Rename crate to durable-streams-reference

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: server-binary
-          path: target/debug/durable-streams-rust-server
+          path: target/debug/durable-streams-reference
 
   conformance:
     name: Protocol Conformance Tests
@@ -67,8 +67,8 @@ jobs:
 
       - name: Start server
         run: |
-          chmod +x durable-streams-rust-server
-          ./durable-streams-rust-server &
+          chmod +x durable-streams-reference
+          ./durable-streams-reference &
         env:
           LONG_POLL_TIMEOUT_SECS: '2'
           SSE_IDLE_CLOSE_SECS: '5'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "durable-streams-rust-server"
+name = "durable-streams-reference"
 version = "0.1.0"
 dependencies = [
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "durable-streams-rust-server"
+name = "durable-streams-reference"
 version = "0.1.0"
 edition = "2024"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN touch src/main.rs src/lib.rs && cargo build --release
 # Stage 2: Runtime
 FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /build/target/release/durable-streams-rust-server /durable-streams-server
+COPY --from=builder /build/target/release/durable-streams-reference /durable-streams-server
 
 EXPOSE 4437
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# durable-streams-rust-server
+# durable-streams-reference
 
-[![CI](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml)
-[![Conformance](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml)
+[![CI](https://github.com/thesampaton/durable-streams-reference/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-reference/actions/workflows/ci.yml)
+[![Conformance](https://github.com/thesampaton/durable-streams-reference/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-reference/actions/workflows/conformance.yml)
 
 Reference implementation of the [durable streams protocol](https://github.com/durable-streams/durable-streams), built on [Electric SQL](https://electric-sql.com/).
 

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,5 +1,5 @@
 [book]
-title = "Durable Streams Rust Server"
+title = "Durable Streams Reference"
 authors = ["Sam Paton"]
 language = "en"
 src = "src"

--- a/docs/book/src/project/contributing.md
+++ b/docs/book/src/project/contributing.md
@@ -3,8 +3,8 @@
 ## Development setup
 
 ```bash
-git clone https://github.com/thesampaton/durable-streams-rust-server.git
-cd durable-streams-rust-server
+git clone https://github.com/thesampaton/durable-streams-reference.git
+cd durable-streams-reference
 cargo build
 cargo test
 ```
@@ -72,4 +72,4 @@ make docs                      # build mdbook documentation
 
 ## Protocol governance
 
-All protocol-level decisions must comply with the governance policies in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/protocol-governance.md). Key rule: never invent semantics. If it is not in spec or tests, record it as a gap.
+All protocol-level decisions must comply with the governance policies in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/protocol-governance.md). Key rule: never invent semantics. If it is not in spec or tests, record it as a gap.

--- a/docs/book/src/project/decisions.md
+++ b/docs/book/src/project/decisions.md
@@ -1,6 +1,6 @@
 # Decision log
 
-Protocol-level implementation decisions are recorded in [`docs/decisions.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/decisions.md). Each entry includes what was decided, why, and a link to the spec section or conformance test that drove the decision.
+Protocol-level implementation decisions are recorded in [`docs/decisions.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/decisions.md). Each entry includes what was decided, why, and a link to the spec section or conformance test that drove the decision.
 
 ## Current decisions
 
@@ -25,4 +25,4 @@ Each decision in the full log includes:
 3. **Rationale:** why this choice was made
 4. **Date:** when the decision was made
 
-When ambiguous, decisions reference the corresponding gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/gaps.md).
+When ambiguous, decisions reference the corresponding gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/gaps.md).

--- a/docs/book/src/project/gaps.md
+++ b/docs/book/src/project/gaps.md
@@ -1,6 +1,6 @@
 # Spec gaps
 
-Ambiguities and edge cases not fully covered by the protocol spec or conformance tests are recorded in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/gaps.md). This page summarizes the current gaps and known ecosystem interop observations.
+Ambiguities and edge cases not fully covered by the protocol spec or conformance tests are recorded in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/gaps.md). This page summarizes the current gaps and known ecosystem interop observations.
 
 ## Active gaps
 
@@ -12,7 +12,7 @@ Gaps are not failures. They are explicit acknowledgments that the implementation
 
 ## Ecosystem interop observations
 
-These are recorded in [`docs/ecosystem-interop.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/ecosystem-interop.md). They are not protocol gaps -- the protocol is fine. They are rough edges in ecosystem components that developers encounter during integration.
+These are recorded in [`docs/ecosystem-interop.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/ecosystem-interop.md). They are not protocol gaps -- the protocol is fine. They are rough edges in ecosystem components that developers encounter during integration.
 
 | ID | Summary | Component |
 |----|---------|-----------|

--- a/docs/book/src/project/governance.md
+++ b/docs/book/src/project/governance.md
@@ -1,6 +1,6 @@
 # Protocol governance
 
-This implementation strictly adheres to the durable streams protocol specification. This page summarizes the governance policies defined in full in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/protocol-governance.md).
+This implementation strictly adheres to the durable streams protocol specification. This page summarizes the governance policies defined in full in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/protocol-governance.md).
 
 ## Default stance
 
@@ -17,7 +17,7 @@ This implementation strictly adheres to the durable streams protocol specificati
 
 ## Spec pinning
 
-The protocol spec is pinned by git commit SHA, not by branch. The conformance test suite is pinned by npm package version. See [`SPEC_VERSION.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/SPEC_VERSION.md) for current pins:
+The protocol spec is pinned by git commit SHA, not by branch. The conformance test suite is pinned by npm package version. See [`SPEC_VERSION.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/SPEC_VERSION.md) for current pins:
 
 - **Spec SHA:** `a347312a47ae510a4a2e3ee7a121d6c8d7d74e50`
 - **Conformance:** `@durable-streams/server-conformance-tests@0.2.1`
@@ -27,7 +27,7 @@ The protocol spec is pinned by git commit SHA, not by branch. The conformance te
 Every externally observable behavior (paths, headers, status codes, framing) must link to:
 - A spec section URL with anchor, or
 - A conformance test that asserts it, or
-- An explicit gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/gaps.md)
+- An explicit gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/gaps.md)
 
 ## Conservative fallback rules
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use durable_streams_rust_server::{config::Config, router, storage::memory::InMemoryStorage};
+use durable_streams_reference::{config::Config, router, storage::memory::InMemoryStorage};
 use std::sync::Arc;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -40,7 +40,7 @@ scaffolding. The external conformance suite is the ultimate acceptance gate.
 ## Black-Box Testing Requirement
 
 Integration tests MUST NOT:
-- Import server modules directly (no `use durable_streams_rust_server::*`)
+- Import server modules directly (no `use durable_streams_reference::*`)
 - Inspect internal state (no accessing storage directly)
 - Mock server behaviour (no fake servers, use the real binary)
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
-use durable_streams_rust_server::config::Config;
-use durable_streams_rust_server::storage::memory::InMemoryStorage;
+use durable_streams_reference::config::Config;
+use durable_streams_reference::storage::memory::InMemoryStorage;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
@@ -61,7 +61,7 @@ async fn spawn_test_server_with_config(config: Config) -> (String, u16) {
     ));
 
     // Build and spawn server
-    let app = durable_streams_rust_server::router::build_router(storage, &config);
+    let app = durable_streams_reference::router::build_router(storage, &config);
 
     tokio::spawn(async move {
         axum::serve(listener, app)


### PR DESCRIPTION
## Summary
- Renames the Cargo crate from `durable-streams-rust-server` to `durable-streams-reference` to match the renamed repository
- Updates binary paths in CI workflow and Dockerfile
- Updates all Rust `use` imports and GitHub URLs in docs

## Test plan
- [x] `cargo test` — all 221 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean