### PR TITLE
Update governance docs and add path-filtered CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [ trunk ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'build.rs'
+      - '.github/workflows/codeql.yml'
+  push:
+    branches: [ trunk ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'build.rs'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 06:00 UTC
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+          queries: +security-extended
+
+      - name: Build
+        run: cargo build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:rust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ any implementation of the protocol.
 
 This implementation strictly adheres to the durable streams protocol specification.
 Governance policies are defined in detail in `docs/protocol-governance.md` and
-`docs/blocker-policy.md` (canonical sources in `scratch/` until copied to `docs/`).
+`docs/blocker-policy.md`.
 
 ### Key Principles
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -51,7 +51,7 @@ Pins the protocol spec and conformance test suite:
 
 ### `docs/protocol-governance.md`
 
-Canonical governance policy. Copied from `scratch/protocol-governance.md`. Defines:
+Canonical governance policy. Defines:
 - Decision hierarchy (conformance tests > spec > maintainer clarification > conservative fallback)
 - Spec pinning requirements
 - Traceability requirements
@@ -59,7 +59,7 @@ Canonical governance policy. Copied from `scratch/protocol-governance.md`. Defin
 
 ### `docs/blocker-policy.md`
 
-Canonical blocker policy. Copied from `scratch/blocker-policy.md`. Defines:
+Canonical blocker policy. Defines:
 - What counts as a blocker
 - Where to log blockers (GitHub issues preferred, `docs/blockers.md` fallback)
 - Required issue format

--- a/docs/book/src/project/decisions.md
+++ b/docs/book/src/project/decisions.md
@@ -15,6 +15,7 @@ Protocol-level implementation decisions are recorded in [`docs/decisions.md`](ht
 | Idempotent close returns 204 | Same status for initial and repeated close |
 | `Stream-Closed: true` on all success responses for closed streams | Consistent header presence lets clients detect closure without HEAD |
 | Sessions + bidirectional DB sync replaces Electric-only test | Sessions pattern is the primary production use case |
+| CORS: allow all origins by default, configurable via `CORS_ORIGINS` | Not part of protocol spec; default suits development, production restricts via env var or proxy |
 
 ## Decision format
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,31 +7,27 @@ and any behaviour differences or breaking changes.
 
 | Spec SHA | Server Version | Status | Notes | Breaking Changes |
 |----------|----------------|--------|-------|------------------|
-| a347312a47ae510a4a2e3ee7a121d6c8d7d74e50 | 0.1.0 | In Development | Initial implementation targeting conformance v0.2.1 | N/A |
+| a347312a47ae510a4a2e3ee7a121d6c8d7d74e50 | 0.1.0 | Complete | Full conformance with @durable-streams/server-conformance-tests@0.2.1 | N/A |
 
 ## Current Implementation
 
-**Server Version:** 0.1.0 (in development)
+**Server Version:** 0.1.0
 
 **Spec SHA:** a347312a47ae510a4a2e3ee7a121d6c8d7d74e50
 
 **Conformance Version:** 0.2.1
 
-**Target:** Full conformance with ~195 tests in the conformance suite.
-
-**Status:** Implementation in progress. Not yet conformant.
+**Status:** Fully conformant. All 239 conformance tests pass.
 
 ## Conformance Coverage
 
-As of 2026-02-06:
-- Implemented: 0/195 tests
-- Passing: 0/195 tests
-
-(Update this section as implementation progresses)
+As of 2026-02-09:
+- Passing: 239/239 tests
 
 ## Known Limitations
 
-None yet (initial implementation).
+- Storage is in-memory only (no persistence across restarts).
+- See `docs/gaps.md` for spec ambiguities and chosen interpretations.
 
 ## Future Compatibility
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -18,6 +18,7 @@ spec sections or conformance tests (or explicit gap references).
 | `Stream-Closed: true` included in ALL success responses where stream is closed | PROTOCOL.md §5.1, §5.2, §5.3 | Consistent header presence lets clients detect closure without a separate HEAD. Applies to POST close, PUT create-closed, and idempotent replays. | 2026-02-08 |
 
 | Replace Electric-only test with Sessions + bidirectional DB sync | N/A (architecture) | DS is lower-level than Electric; the sessions pattern is the primary production use case. Bidirectional PG sync validates the full data layer (DS for real-time delivery, PG for durable querying). The `integration-test-electric` stub is replaced by `integration-test-sessions` which tests both directions: PG->DS via Electric Shape API, and DS->PG via SSE consumer. | 2026-02-09 |
+| CORS: allow all origins by default, configurable via `CORS_ORIGINS` | Gap: `docs/gaps.md` example entry (CORS not covered by conformance) | CORS is not part of the protocol spec or conformance tests. Default allow-all suits development; production deployments restrict via env var or auth proxy. Keeps CORS config out of protocol semantics. | 2026-02-09 |
 
 ## Decision Entry Format
 

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -20,12 +20,14 @@ When adding a gap, include:
 4. **Clarifying Test:** What conformance test or spec clarification would resolve this
 5. **Date:** When the gap was recorded (YYYY-MM-DD)
 
-## Example Entry
+## Example Entry (format reference only, not real gaps)
+
+The entries below illustrate the expected format. They are not active or resolved gaps.
 
 | Ambiguity | Interpretation | Why Conservative | Clarifying Test | Date |
 |-----------|----------------|------------------|-----------------|------|
-| CORS not covered by conformance | Allow all origins by default, configurable via `CORS_ORIGINS` env var | Aligns with typical development defaults, restrictable in production. Not adding protocol-level headers that might conflict with future spec. | Test OPTIONS preflight with various Origin headers; verify Access-Control-Allow-* headers | 2026-02-06 |
-| Health check endpoint path | `/healthz` outside `/v1/stream/` namespace | Health checks are infrastructure, not protocol API. Separate namespaces prevent confusion. | N/A - health check is implementation detail | 2026-02-06 |
+| _Example:_ CORS not covered by conformance | Allow all origins by default, configurable via `CORS_ORIGINS` env var | Aligns with typical development defaults, restrictable in production. Not adding protocol-level headers that might conflict with future spec. | Test OPTIONS preflight with various Origin headers; verify Access-Control-Allow-* headers | 2026-02-06 |
+| _Example:_ Health check endpoint path | `/healthz` outside `/v1/stream/` namespace | Health checks are infrastructure, not protocol API. Separate namespaces prevent confusion. | N/A - health check is implementation detail | 2026-02-06 |
 
 ## Resolved Gaps
 


### PR DESCRIPTION
## Summary

- **Fix outdated compatibility.md**: Was claiming "0/195 tests, in development" when reality is 239/239 fully conformant
- **Add missing CORS decision**: Commit b7ee470 wired up CORS but no decision entry existed in docs/decisions.md
- **Remove stale scratch/ references**: No scratch/ directory exists; cleaned from CLAUDE.md and docs/CLAUDE.md
- **Clarify example entries in gaps.md**: Prefixed with "_Example:_" and added header note to prevent confusion with real gaps
- **Sync mdbook decisions page**: Added CORS decision to docs/book/src/project/decisions.md
- **Add path-filtered CodeQL workflow**: Replaces default setup so CodeQL only runs when Rust source changes (src/, tests/, Cargo.toml, Cargo.lock). Docs-only PRs skip CodeQL entirely. Weekly scheduled scan preserved.

## Test plan

- [ ] Verify CI passes (lint, test, governance checks)
- [ ] Verify CodeQL workflow triggers correctly on this PR (has workflow file change in paths)
- [ ] Confirm docs-only PRs will skip CodeQL going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)