### PR TITLE
Add file storage backend and benchmark suite

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: rust
           queries: +security-extended
@@ -44,6 +44,6 @@ jobs:
         run: cargo build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:rust

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo "  benchmark-node        - Run benchmark-node-memory then benchmark-node-file"
 	@echo "  benchmark-node-memory - Run benchmark suite against Node reference (memory)"
 	@echo "  benchmark-node-file   - Run benchmark suite against Node reference (file)"
+	@echo "  (Use BENCHMARK_VERBOSE=1 for verbose benchmark output)"
 	@echo "  integration-test      - Run full stack integration test (Docker)"
 	@echo "  integration-test-sessions - Run sessions + DB sync test (Docker)"
 	@echo ""
@@ -105,6 +106,14 @@ BENCHMARK_DIR := /tmp/benchmark-run
 BENCHMARK_VERSION := 0.2.1
 BENCHMARK_PORT := 4437
 BENCHMARK_FILE_STORAGE_DIR := /tmp/benchmark-file-storage
+BENCHMARK_MAX_MEMORY_BYTES ?= 536870912
+BENCHMARK_MAX_STREAM_BYTES ?= 268435456
+BENCHMARK_VERBOSE ?= 0
+ifeq ($(BENCHMARK_VERBOSE),1)
+BENCHMARK_VITEST_FLAGS := --reporter=verbose
+else
+BENCHMARK_VITEST_FLAGS := --silent=passed-only
+endif
 BENCHMARK_NODE_PORT := 4438
 BENCHMARK_NODE_FILE_STORAGE_DIR := /tmp/node-ref-file-store
 NODE_REF_DIR := .dev/durable-streams
@@ -127,9 +136,18 @@ benchmark: benchmark-memory benchmark-file
 
 benchmark-memory: release $(BENCHMARK_DIR)/node_modules
 	@set -e; \
+	SERVER_PID=""; \
+	cleanup() { \
+		if [ -n "$$SERVER_PID" ]; then \
+			kill $$SERVER_PID 2>/dev/null || true; \
+			wait $$SERVER_PID 2>/dev/null || true; \
+			SERVER_PID=""; \
+		fi; \
+	}; \
+	trap cleanup EXIT INT TERM; \
 	echo ""; \
 	echo "=== Benchmark backend: memory ==="; \
-	STORAGE_MODE=memory cargo run --release & SERVER_PID=$$!; \
+	PORT=$(BENCHMARK_PORT) MAX_MEMORY_BYTES=$(BENCHMARK_MAX_MEMORY_BYTES) MAX_STREAM_BYTES=$(BENCHMARK_MAX_STREAM_BYTES) STORAGE_MODE=memory cargo run --release & SERVER_PID=$$!; \
 	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
 	HEALTHY=0; \
 	for i in $$(seq 1 30); do \
@@ -150,11 +168,10 @@ benchmark-memory: release $(BENCHMARK_DIR)/node_modules
 		exit 1; \
 	fi; \
 	echo "Running benchmarks for memory storage..."; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
 	RESULT=$$?; \
 	echo "Stopping server for memory..."; \
-	kill $$SERVER_PID 2>/dev/null || true; \
-	wait $$SERVER_PID 2>/dev/null || true; \
+	cleanup; \
 	for i in $$(seq 1 10); do \
 		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
 			sleep 1; \
@@ -170,10 +187,19 @@ benchmark-memory: release $(BENCHMARK_DIR)/node_modules
 
 benchmark-file: release $(BENCHMARK_DIR)/node_modules
 	@set -e; \
+	SERVER_PID=""; \
+	cleanup() { \
+		if [ -n "$$SERVER_PID" ]; then \
+			kill $$SERVER_PID 2>/dev/null || true; \
+			wait $$SERVER_PID 2>/dev/null || true; \
+			SERVER_PID=""; \
+		fi; \
+	}; \
+	trap cleanup EXIT INT TERM; \
 	echo ""; \
 	echo "=== Benchmark backend: file ==="; \
 	rm -rf $(BENCHMARK_FILE_STORAGE_DIR); \
-	STORAGE_MODE=file-durable STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
+	PORT=$(BENCHMARK_PORT) MAX_MEMORY_BYTES=$(BENCHMARK_MAX_MEMORY_BYTES) MAX_STREAM_BYTES=$(BENCHMARK_MAX_STREAM_BYTES) STORAGE_MODE=file-durable STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
 	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
 	HEALTHY=0; \
 	for i in $$(seq 1 30); do \
@@ -194,11 +220,10 @@ benchmark-file: release $(BENCHMARK_DIR)/node_modules
 		exit 1; \
 	fi; \
 	echo "Running benchmarks for file storage..."; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
 	RESULT=$$?; \
 	echo "Stopping server for file..."; \
-	kill $$SERVER_PID 2>/dev/null || true; \
-	wait $$SERVER_PID 2>/dev/null || true; \
+	cleanup; \
 	for i in $$(seq 1 10); do \
 		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
 			sleep 1; \
@@ -224,6 +249,15 @@ node-ref-build:
 
 benchmark-node-memory: node-ref-build $(BENCHMARK_DIR)/node_modules
 	@set -e; \
+	SERVER_PID=""; \
+	cleanup() { \
+		if [ -n "$$SERVER_PID" ]; then \
+			kill $$SERVER_PID 2>/dev/null || true; \
+			wait $$SERVER_PID 2>/dev/null || true; \
+			SERVER_PID=""; \
+		fi; \
+	}; \
+	trap cleanup EXIT INT TERM; \
 	echo ""; \
 	echo "=== Node reference benchmark backend: memory ==="; \
 	NODE_REF_SERVER_MODULE=$(NODE_REF_SERVER_MODULE) MODE=memory HOST=127.0.0.1 PORT=$(BENCHMARK_NODE_PORT) node $(NODE_REF_RUNNER) & SERVER_PID=$$!; \
@@ -245,10 +279,9 @@ benchmark-node-memory: node-ref-build $(BENCHMARK_DIR)/node_modules
 		wait $$SERVER_PID 2>/dev/null || true; \
 		exit 1; \
 	fi; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
 	RESULT=$$?; \
-	kill $$SERVER_PID 2>/dev/null || true; \
-	wait $$SERVER_PID 2>/dev/null || true; \
+	cleanup; \
 	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
 		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-node-memory.json; \
 		echo "Saved node-memory results to $(BENCHMARK_DIR)/benchmark-results-node-memory.json"; \
@@ -257,6 +290,15 @@ benchmark-node-memory: node-ref-build $(BENCHMARK_DIR)/node_modules
 
 benchmark-node-file: node-ref-build $(BENCHMARK_DIR)/node_modules
 	@set -e; \
+	SERVER_PID=""; \
+	cleanup() { \
+		if [ -n "$$SERVER_PID" ]; then \
+			kill $$SERVER_PID 2>/dev/null || true; \
+			wait $$SERVER_PID 2>/dev/null || true; \
+			SERVER_PID=""; \
+		fi; \
+	}; \
+	trap cleanup EXIT INT TERM; \
 	echo ""; \
 	echo "=== Node reference benchmark backend: file ==="; \
 	rm -rf $(BENCHMARK_NODE_FILE_STORAGE_DIR); \
@@ -279,10 +321,9 @@ benchmark-node-file: node-ref-build $(BENCHMARK_DIR)/node_modules
 		wait $$SERVER_PID 2>/dev/null || true; \
 		exit 1; \
 	fi; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
 	RESULT=$$?; \
-	kill $$SERVER_PID 2>/dev/null || true; \
-	wait $$SERVER_PID 2>/dev/null || true; \
+	cleanup; \
 	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
 		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-node-file.json; \
 		echo "Saved node-file results to $(BENCHMARK_DIR)/benchmark-results-node-file.json"; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: build release lint fmt-check test conformance benchmark integration-test integration-test-sessions integration-test-electric docker docker-up docker-down docs docs-serve clean help dev dev-down dev-ui
+.PHONY: build release lint fmt-check test conformance benchmark benchmark-memory benchmark-file benchmark-node benchmark-node-memory benchmark-node-file node-ref-build integration-test integration-test-sessions integration-test-electric docker docker-up docker-down docs docs-serve clean help dev dev-down dev-ui
+.NOTPARALLEL: benchmark benchmark-memory benchmark-file benchmark-node benchmark-node-memory benchmark-node-file
 
 # Default target
 help:
@@ -18,7 +19,12 @@ help:
 	@echo "  test-unit             - Run unit tests only"
 	@echo "  test-integration      - Run Rust integration tests only"
 	@echo "  conformance           - Run external conformance test suite"
-	@echo "  benchmark             - Run benchmark suite (release build)"
+	@echo "  benchmark             - Run benchmark-memory then benchmark-file (release)"
+	@echo "  benchmark-memory      - Run benchmark suite with in-memory storage"
+	@echo "  benchmark-file        - Run benchmark suite with file storage"
+	@echo "  benchmark-node        - Run benchmark-node-memory then benchmark-node-file"
+	@echo "  benchmark-node-memory - Run benchmark suite against Node reference (memory)"
+	@echo "  benchmark-node-file   - Run benchmark suite against Node reference (file)"
 	@echo "  integration-test      - Run full stack integration test (Docker)"
 	@echo "  integration-test-sessions - Run sessions + DB sync test (Docker)"
 	@echo ""
@@ -93,9 +99,17 @@ conformance: build $(CONFORMANCE_DIR)/node_modules
 # Benchmark target
 # Requires: node, npm
 # On first run, installs the benchmark harness to /tmp/benchmark-run
-# Builds and runs the server with --release for accurate performance numbers
+# Builds and runs the server with --release for accurate performance numbers.
+# Runs benchmarks for both storage backends and saves separate result files.
 BENCHMARK_DIR := /tmp/benchmark-run
 BENCHMARK_VERSION := 0.2.1
+BENCHMARK_PORT := 4437
+BENCHMARK_FILE_STORAGE_DIR := /tmp/benchmark-file-storage
+BENCHMARK_NODE_PORT := 4438
+BENCHMARK_NODE_FILE_STORAGE_DIR := /tmp/node-ref-file-store
+NODE_REF_DIR := .dev/durable-streams
+NODE_REF_SERVER_MODULE := $(NODE_REF_DIR)/packages/server/dist/index.js
+NODE_REF_RUNNER := scripts/node_ref_benchmark_server.mjs
 
 $(BENCHMARK_DIR)/node_modules: $(BENCHMARK_DIR)/package.json
 	cd $(BENCHMARK_DIR) && npm install
@@ -105,20 +119,173 @@ $(BENCHMARK_DIR)/package.json:
 	cd $(BENCHMARK_DIR) && npm init -y && npm install @durable-streams/benchmarks@$(BENCHMARK_VERSION)
 	printf 'import { runBenchmarks } from "@durable-streams/benchmarks";\nconst baseUrl = process.env.BENCHMARK_URL;\nif (!baseUrl) throw new Error("BENCHMARK_URL is required");\nrunBenchmarks({ baseUrl, environment: process.env.BENCHMARK_ENV || "local" });\n' > $(BENCHMARK_DIR)/benchmark.bench.mjs
 
-benchmark: release $(BENCHMARK_DIR)/node_modules
-	@echo "Starting server (release build) on port 4437..."
-	@cargo run --release & SERVER_PID=$$!; \
-	echo "Waiting for health check..."; \
-	for i in $$(seq 1 30); do curl -s http://localhost:4437/healthz > /dev/null 2>&1 && break; sleep 1; done; \
-	echo "Running benchmarks..."; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:4437 npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+benchmark: benchmark-memory benchmark-file
+	@echo ""
+	@echo "Benchmark comparison files:"
+	@echo "  $(BENCHMARK_DIR)/benchmark-results-memory.json"
+	@echo "  $(BENCHMARK_DIR)/benchmark-results-file.json"
+
+benchmark-memory: release $(BENCHMARK_DIR)/node_modules
+	@set -e; \
+	echo ""; \
+	echo "=== Benchmark backend: memory ==="; \
+	STORAGE_BACKEND=memory STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
+	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
+	HEALTHY=0; \
+	for i in $$(seq 1 30); do \
+		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
+			HEALTHY=1; \
+			break; \
+		fi; \
+		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
+			echo "Server for memory exited before becoming healthy"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done; \
+	if [ $$HEALTHY -ne 1 ]; then \
+		echo "Server for memory did not pass health check in time"; \
+		kill $$SERVER_PID 2>/dev/null || true; \
+		wait $$SERVER_PID 2>/dev/null || true; \
+		exit 1; \
+	fi; \
+	echo "Running benchmarks for memory storage..."; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
 	RESULT=$$?; \
-	echo "Stopping server..."; \
+	echo "Stopping server for memory..."; \
+	kill $$SERVER_PID 2>/dev/null || true; \
+	wait $$SERVER_PID 2>/dev/null || true; \
+	for i in $$(seq 1 10); do \
+		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
+			sleep 1; \
+		else \
+			break; \
+		fi; \
+	done; \
+	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
+		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-memory.json; \
+		echo "Saved memory results to $(BENCHMARK_DIR)/benchmark-results-memory.json"; \
+	fi; \
+	exit $$RESULT
+
+benchmark-file: release $(BENCHMARK_DIR)/node_modules
+	@set -e; \
+	echo ""; \
+	echo "=== Benchmark backend: file ==="; \
+	rm -rf $(BENCHMARK_FILE_STORAGE_DIR); \
+	STORAGE_BACKEND=file STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
+	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
+	HEALTHY=0; \
+	for i in $$(seq 1 30); do \
+		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
+			HEALTHY=1; \
+			break; \
+		fi; \
+		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
+			echo "Server for file exited before becoming healthy"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done; \
+	if [ $$HEALTHY -ne 1 ]; then \
+		echo "Server for file did not pass health check in time"; \
+		kill $$SERVER_PID 2>/dev/null || true; \
+		wait $$SERVER_PID 2>/dev/null || true; \
+		exit 1; \
+	fi; \
+	echo "Running benchmarks for file storage..."; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+	RESULT=$$?; \
+	echo "Stopping server for file..."; \
+	kill $$SERVER_PID 2>/dev/null || true; \
+	wait $$SERVER_PID 2>/dev/null || true; \
+	for i in $$(seq 1 10); do \
+		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
+			sleep 1; \
+		else \
+			break; \
+		fi; \
+	done; \
+	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
+		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-file.json; \
+		echo "Saved file results to $(BENCHMARK_DIR)/benchmark-results-file.json"; \
+	fi; \
+	exit $$RESULT
+
+benchmark-node: benchmark-node-memory benchmark-node-file
+	@echo ""
+	@echo "Node benchmark comparison files:"
+	@echo "  $(BENCHMARK_DIR)/benchmark-results-node-memory.json"
+	@echo "  $(BENCHMARK_DIR)/benchmark-results-node-file.json"
+
+node-ref-build:
+	@test -d $(NODE_REF_DIR) || (echo "Missing $(NODE_REF_DIR). Run 'make dev-ui' first." && exit 1)
+	@cd $(NODE_REF_DIR) && pnpm --filter @durable-streams/server build
+
+benchmark-node-memory: node-ref-build $(BENCHMARK_DIR)/node_modules
+	@set -e; \
+	echo ""; \
+	echo "=== Node reference benchmark backend: memory ==="; \
+	NODE_REF_SERVER_MODULE=$(NODE_REF_SERVER_MODULE) MODE=memory HOST=127.0.0.1 PORT=$(BENCHMARK_NODE_PORT) node $(NODE_REF_RUNNER) & SERVER_PID=$$!; \
+	READY=0; \
+	for i in $$(seq 1 30); do \
+		if curl -s http://127.0.0.1:$(BENCHMARK_NODE_PORT)/ > /dev/null 2>&1; then \
+			READY=1; \
+			break; \
+		fi; \
+		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
+			echo "Node reference server (memory) exited before becoming ready"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done; \
+	if [ $$READY -ne 1 ]; then \
+		echo "Node reference server (memory) did not become reachable in time"; \
+		kill $$SERVER_PID 2>/dev/null || true; \
+		wait $$SERVER_PID 2>/dev/null || true; \
+		exit 1; \
+	fi; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+	RESULT=$$?; \
 	kill $$SERVER_PID 2>/dev/null || true; \
 	wait $$SERVER_PID 2>/dev/null || true; \
 	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
-		echo ""; \
-		echo "Results saved to $(BENCHMARK_DIR)/benchmark-results.json"; \
+		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-node-memory.json; \
+		echo "Saved node-memory results to $(BENCHMARK_DIR)/benchmark-results-node-memory.json"; \
+	fi; \
+	exit $$RESULT
+
+benchmark-node-file: node-ref-build $(BENCHMARK_DIR)/node_modules
+	@set -e; \
+	echo ""; \
+	echo "=== Node reference benchmark backend: file ==="; \
+	rm -rf $(BENCHMARK_NODE_FILE_STORAGE_DIR); \
+	NODE_REF_SERVER_MODULE=$(NODE_REF_SERVER_MODULE) MODE=file DATA_DIR=$(BENCHMARK_NODE_FILE_STORAGE_DIR) HOST=127.0.0.1 PORT=$(BENCHMARK_NODE_PORT) node $(NODE_REF_RUNNER) & SERVER_PID=$$!; \
+	READY=0; \
+	for i in $$(seq 1 30); do \
+		if curl -s http://127.0.0.1:$(BENCHMARK_NODE_PORT)/ > /dev/null 2>&1; then \
+			READY=1; \
+			break; \
+		fi; \
+		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
+			echo "Node reference server (file) exited before becoming ready"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done; \
+	if [ $$READY -ne 1 ]; then \
+		echo "Node reference server (file) did not become reachable in time"; \
+		kill $$SERVER_PID 2>/dev/null || true; \
+		wait $$SERVER_PID 2>/dev/null || true; \
+		exit 1; \
+	fi; \
+	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --reporter=verbose benchmark.bench.mjs; \
+	RESULT=$$?; \
+	kill $$SERVER_PID 2>/dev/null || true; \
+	wait $$SERVER_PID 2>/dev/null || true; \
+	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
+		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-node-file.json; \
+		echo "Saved node-file results to $(BENCHMARK_DIR)/benchmark-results-node-file.json"; \
 	fi; \
 	exit $$RESULT
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help:
 	@echo "  conformance           - Run external conformance test suite"
 	@echo "  benchmark             - Run benchmark-memory then benchmark-file (release)"
 	@echo "  benchmark-memory      - Run benchmark suite with in-memory storage"
-	@echo "  benchmark-file        - Run benchmark suite with file storage"
+	@echo "  benchmark-file        - Run benchmark suite with file storage (durable mode)"
 	@echo "  benchmark-node        - Run benchmark-node-memory then benchmark-node-file"
 	@echo "  benchmark-node-memory - Run benchmark suite against Node reference (memory)"
 	@echo "  benchmark-node-file   - Run benchmark suite against Node reference (file)"
@@ -129,7 +129,7 @@ benchmark-memory: release $(BENCHMARK_DIR)/node_modules
 	@set -e; \
 	echo ""; \
 	echo "=== Benchmark backend: memory ==="; \
-	STORAGE_BACKEND=memory STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
+	STORAGE_MODE=memory cargo run --release & SERVER_PID=$$!; \
 	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
 	HEALTHY=0; \
 	for i in $$(seq 1 30); do \
@@ -173,7 +173,7 @@ benchmark-file: release $(BENCHMARK_DIR)/node_modules
 	echo ""; \
 	echo "=== Benchmark backend: file ==="; \
 	rm -rf $(BENCHMARK_FILE_STORAGE_DIR); \
-	STORAGE_BACKEND=file STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
+	STORAGE_MODE=file-durable STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
 	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
 	HEALTHY=0; \
 	for i in $$(seq 1 30); do \

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,8 @@ $(BENCHMARK_DIR)/package.json:
 	cd $(BENCHMARK_DIR) && npm init -y && npm install @durable-streams/benchmarks@$(BENCHMARK_VERSION)
 	printf 'import { runBenchmarks } from "@durable-streams/benchmarks";\nconst baseUrl = process.env.BENCHMARK_URL;\nif (!baseUrl) throw new Error("BENCHMARK_URL is required");\nrunBenchmarks({ baseUrl, environment: process.env.BENCHMARK_ENV || "local" });\n' > $(BENCHMARK_DIR)/benchmark.bench.mjs
 
+BENCH_SCRIPT := scripts/run_benchmark.sh
+
 benchmark: benchmark-memory benchmark-file
 	@echo ""
 	@echo "Benchmark comparison files:"
@@ -135,107 +137,15 @@ benchmark: benchmark-memory benchmark-file
 	@echo "  $(BENCHMARK_DIR)/benchmark-results-file.json"
 
 benchmark-memory: release $(BENCHMARK_DIR)/node_modules
-	@set -e; \
-	SERVER_PID=""; \
-	cleanup() { \
-		if [ -n "$$SERVER_PID" ]; then \
-			kill $$SERVER_PID 2>/dev/null || true; \
-			wait $$SERVER_PID 2>/dev/null || true; \
-			SERVER_PID=""; \
-		fi; \
-	}; \
-	trap cleanup EXIT INT TERM; \
-	echo ""; \
-	echo "=== Benchmark backend: memory ==="; \
-	PORT=$(BENCHMARK_PORT) MAX_MEMORY_BYTES=$(BENCHMARK_MAX_MEMORY_BYTES) MAX_STREAM_BYTES=$(BENCHMARK_MAX_STREAM_BYTES) STORAGE_MODE=memory cargo run --release & SERVER_PID=$$!; \
-	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
-	HEALTHY=0; \
-	for i in $$(seq 1 30); do \
-		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
-			HEALTHY=1; \
-			break; \
-		fi; \
-		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
-			echo "Server for memory exited before becoming healthy"; \
-			exit 1; \
-		fi; \
-		sleep 1; \
-	done; \
-	if [ $$HEALTHY -ne 1 ]; then \
-		echo "Server for memory did not pass health check in time"; \
-		kill $$SERVER_PID 2>/dev/null || true; \
-		wait $$SERVER_PID 2>/dev/null || true; \
-		exit 1; \
-	fi; \
-	echo "Running benchmarks for memory storage..."; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
-	RESULT=$$?; \
-	echo "Stopping server for memory..."; \
-	cleanup; \
-	for i in $$(seq 1 10); do \
-		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
-			sleep 1; \
-		else \
-			break; \
-		fi; \
-	done; \
-	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
-		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-memory.json; \
-		echo "Saved memory results to $(BENCHMARK_DIR)/benchmark-results-memory.json"; \
-	fi; \
-	exit $$RESULT
+	@BENCHMARK_DIR=$(BENCHMARK_DIR) BENCHMARK_VITEST_FLAGS="$(BENCHMARK_VITEST_FLAGS)" \
+		$(BENCH_SCRIPT) "memory" localhost $(BENCHMARK_PORT) /healthz memory \
+		env PORT=$(BENCHMARK_PORT) MAX_MEMORY_BYTES=$(BENCHMARK_MAX_MEMORY_BYTES) MAX_STREAM_BYTES=$(BENCHMARK_MAX_STREAM_BYTES) STORAGE_MODE=memory cargo run --release
 
 benchmark-file: release $(BENCHMARK_DIR)/node_modules
-	@set -e; \
-	SERVER_PID=""; \
-	cleanup() { \
-		if [ -n "$$SERVER_PID" ]; then \
-			kill $$SERVER_PID 2>/dev/null || true; \
-			wait $$SERVER_PID 2>/dev/null || true; \
-			SERVER_PID=""; \
-		fi; \
-	}; \
-	trap cleanup EXIT INT TERM; \
-	echo ""; \
-	echo "=== Benchmark backend: file ==="; \
-	rm -rf $(BENCHMARK_FILE_STORAGE_DIR); \
-	PORT=$(BENCHMARK_PORT) MAX_MEMORY_BYTES=$(BENCHMARK_MAX_MEMORY_BYTES) MAX_STREAM_BYTES=$(BENCHMARK_MAX_STREAM_BYTES) STORAGE_MODE=file-durable STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release & SERVER_PID=$$!; \
-	echo "Waiting for health check on :$(BENCHMARK_PORT)..."; \
-	HEALTHY=0; \
-	for i in $$(seq 1 30); do \
-		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
-			HEALTHY=1; \
-			break; \
-		fi; \
-		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
-			echo "Server for file exited before becoming healthy"; \
-			exit 1; \
-		fi; \
-		sleep 1; \
-	done; \
-	if [ $$HEALTHY -ne 1 ]; then \
-		echo "Server for file did not pass health check in time"; \
-		kill $$SERVER_PID 2>/dev/null || true; \
-		wait $$SERVER_PID 2>/dev/null || true; \
-		exit 1; \
-	fi; \
-	echo "Running benchmarks for file storage..."; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://localhost:$(BENCHMARK_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
-	RESULT=$$?; \
-	echo "Stopping server for file..."; \
-	cleanup; \
-	for i in $$(seq 1 10); do \
-		if curl -s http://localhost:$(BENCHMARK_PORT)/healthz > /dev/null 2>&1; then \
-			sleep 1; \
-		else \
-			break; \
-		fi; \
-	done; \
-	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
-		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-file.json; \
-		echo "Saved file results to $(BENCHMARK_DIR)/benchmark-results-file.json"; \
-	fi; \
-	exit $$RESULT
+	@rm -rf $(BENCHMARK_FILE_STORAGE_DIR)
+	@BENCHMARK_DIR=$(BENCHMARK_DIR) BENCHMARK_VITEST_FLAGS="$(BENCHMARK_VITEST_FLAGS)" \
+		$(BENCH_SCRIPT) "file (durable)" localhost $(BENCHMARK_PORT) /healthz file \
+		env PORT=$(BENCHMARK_PORT) MAX_MEMORY_BYTES=$(BENCHMARK_MAX_MEMORY_BYTES) MAX_STREAM_BYTES=$(BENCHMARK_MAX_STREAM_BYTES) STORAGE_MODE=file-durable STORAGE_DIR=$(BENCHMARK_FILE_STORAGE_DIR) cargo run --release
 
 benchmark-node: benchmark-node-memory benchmark-node-file
 	@echo ""
@@ -248,87 +158,15 @@ node-ref-build:
 	@cd $(NODE_REF_DIR) && pnpm --filter @durable-streams/server build
 
 benchmark-node-memory: node-ref-build $(BENCHMARK_DIR)/node_modules
-	@set -e; \
-	SERVER_PID=""; \
-	cleanup() { \
-		if [ -n "$$SERVER_PID" ]; then \
-			kill $$SERVER_PID 2>/dev/null || true; \
-			wait $$SERVER_PID 2>/dev/null || true; \
-			SERVER_PID=""; \
-		fi; \
-	}; \
-	trap cleanup EXIT INT TERM; \
-	echo ""; \
-	echo "=== Node reference benchmark backend: memory ==="; \
-	NODE_REF_SERVER_MODULE=$(NODE_REF_SERVER_MODULE) MODE=memory HOST=127.0.0.1 PORT=$(BENCHMARK_NODE_PORT) node $(NODE_REF_RUNNER) & SERVER_PID=$$!; \
-	READY=0; \
-	for i in $$(seq 1 30); do \
-		if curl -s http://127.0.0.1:$(BENCHMARK_NODE_PORT)/ > /dev/null 2>&1; then \
-			READY=1; \
-			break; \
-		fi; \
-		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
-			echo "Node reference server (memory) exited before becoming ready"; \
-			exit 1; \
-		fi; \
-		sleep 1; \
-	done; \
-	if [ $$READY -ne 1 ]; then \
-		echo "Node reference server (memory) did not become reachable in time"; \
-		kill $$SERVER_PID 2>/dev/null || true; \
-		wait $$SERVER_PID 2>/dev/null || true; \
-		exit 1; \
-	fi; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
-	RESULT=$$?; \
-	cleanup; \
-	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
-		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-node-memory.json; \
-		echo "Saved node-memory results to $(BENCHMARK_DIR)/benchmark-results-node-memory.json"; \
-	fi; \
-	exit $$RESULT
+	@BENCHMARK_DIR=$(BENCHMARK_DIR) BENCHMARK_VITEST_FLAGS="$(BENCHMARK_VITEST_FLAGS)" \
+		$(BENCH_SCRIPT) "Node reference (memory)" 127.0.0.1 $(BENCHMARK_NODE_PORT) / node-memory \
+		env NODE_REF_SERVER_MODULE=$(NODE_REF_SERVER_MODULE) MODE=memory HOST=127.0.0.1 PORT=$(BENCHMARK_NODE_PORT) node $(NODE_REF_RUNNER)
 
 benchmark-node-file: node-ref-build $(BENCHMARK_DIR)/node_modules
-	@set -e; \
-	SERVER_PID=""; \
-	cleanup() { \
-		if [ -n "$$SERVER_PID" ]; then \
-			kill $$SERVER_PID 2>/dev/null || true; \
-			wait $$SERVER_PID 2>/dev/null || true; \
-			SERVER_PID=""; \
-		fi; \
-	}; \
-	trap cleanup EXIT INT TERM; \
-	echo ""; \
-	echo "=== Node reference benchmark backend: file ==="; \
-	rm -rf $(BENCHMARK_NODE_FILE_STORAGE_DIR); \
-	NODE_REF_SERVER_MODULE=$(NODE_REF_SERVER_MODULE) MODE=file DATA_DIR=$(BENCHMARK_NODE_FILE_STORAGE_DIR) HOST=127.0.0.1 PORT=$(BENCHMARK_NODE_PORT) node $(NODE_REF_RUNNER) & SERVER_PID=$$!; \
-	READY=0; \
-	for i in $$(seq 1 30); do \
-		if curl -s http://127.0.0.1:$(BENCHMARK_NODE_PORT)/ > /dev/null 2>&1; then \
-			READY=1; \
-			break; \
-		fi; \
-		if ! kill -0 $$SERVER_PID 2>/dev/null; then \
-			echo "Node reference server (file) exited before becoming ready"; \
-			exit 1; \
-		fi; \
-		sleep 1; \
-	done; \
-	if [ $$READY -ne 1 ]; then \
-		echo "Node reference server (file) did not become reachable in time"; \
-		kill $$SERVER_PID 2>/dev/null || true; \
-		wait $$SERVER_PID 2>/dev/null || true; \
-		exit 1; \
-	fi; \
-	cd $(BENCHMARK_DIR) && BENCHMARK_URL=http://127.0.0.1:$(BENCHMARK_NODE_PORT) npx vitest bench --run $(BENCHMARK_VITEST_FLAGS) benchmark.bench.mjs; \
-	RESULT=$$?; \
-	cleanup; \
-	if [ -f $(BENCHMARK_DIR)/benchmark-results.json ]; then \
-		cp $(BENCHMARK_DIR)/benchmark-results.json $(BENCHMARK_DIR)/benchmark-results-node-file.json; \
-		echo "Saved node-file results to $(BENCHMARK_DIR)/benchmark-results-node-file.json"; \
-	fi; \
-	exit $$RESULT
+	@rm -rf $(BENCHMARK_NODE_FILE_STORAGE_DIR)
+	@BENCHMARK_DIR=$(BENCHMARK_DIR) BENCHMARK_VITEST_FLAGS="$(BENCHMARK_VITEST_FLAGS)" \
+		$(BENCH_SCRIPT) "Node reference (file)" 127.0.0.1 $(BENCHMARK_NODE_PORT) / node-file \
+		env NODE_REF_SERVER_MODULE=$(NODE_REF_SERVER_MODULE) MODE=file DATA_DIR=$(BENCHMARK_NODE_FILE_STORAGE_DIR) HOST=127.0.0.1 PORT=$(BENCHMARK_NODE_PORT) node $(NODE_REF_RUNNER)
 
 # End-to-end integration tests against the Docker stack (server + Envoy JWT proxy)
 integration-test: docker

--- a/docs/benchmark-report.md
+++ b/docs/benchmark-report.md
@@ -1,0 +1,53 @@
+# Benchmark Report
+
+- Generated (Local): 2026-02-09 21:53:39 AEDT
+- Generated (UTC): 2026-02-09 10:53:39 UTC
+- Branch: `feat/filestorage`
+- Current commit (short): `1df0d84`
+- Commit links: TODO (to be added)
+
+## Run Setup
+
+- Rust benchmarks: `make benchmark`
+- Node benchmarks: `make benchmark-node`
+- Harness: `@durable-streams/benchmarks` in `/tmp/benchmark-run`
+- Result artifacts:
+  - `/tmp/benchmark-run/benchmark-results-memory.json`
+  - `/tmp/benchmark-run/benchmark-results-file.json`
+  - `/tmp/benchmark-run/benchmark-results-node-memory.json`
+  - `/tmp/benchmark-run/benchmark-results-node-file.json`
+
+## Core Metrics (Mean / P99)
+
+| Implementation | RTT Latency Mean (ms) | RTT Latency P99 (ms) | Small Msg Throughput Mean (msg/s) | Small Msg P99 (msg/s) | Large Msg Throughput Mean (msg/s) | Large Msg P99 (msg/s) |
+|---|---:|---:|---:|---:|---:|---:|
+| Rust Memory | 0.402 | 1.008 | 351,923 | 416,428 | 1,789 | 2,176 |
+| Rust File | 5.666 | 7.219 | 6,507 | 6,996 | 518 | 564 |
+| Node Memory | 0.357 | 0.663 | 311,644 | 365,620 | 1,567 | 1,920 |
+| Node File | 10.382 | 11.985 | 3,701 | 3,875 | 366 | 390 |
+
+## Cross-Implementation Ratios
+
+| Comparison | Ratio |
+|---|---:|
+| Memory latency (Node/Rust) | 0.889x |
+| Memory small throughput (Rust/Node) | 1.129x |
+| Memory large throughput (Rust/Node) | 1.142x |
+| File latency (Node/Rust) | 1.832x |
+| File small throughput (Rust/Node) | 1.758x |
+| File large throughput (Rust/Node) | 1.417x |
+
+## Memory -> File Degradation
+
+| Implementation | Latency Increase (File/Memory) | Small Throughput Retained | Large Throughput Retained |
+|---|---:|---:|---:|
+| Rust | 14.10x slower | 1.85% | 28.99% |
+| Node | 29.06x slower | 1.19% | 23.36% |
+
+## Notes
+
+- File-mode benchmarks were run with Rust durable mode (`STORAGE_MODE=file-durable`).
+- Rust benchmark limits were increased for this run so large-message scenarios fit:
+  - `MAX_MEMORY_BYTES=536870912`
+  - `MAX_STREAM_BYTES=268435456`
+- Benchmark output mode defaults to quiet; set `BENCHMARK_VERBOSE=1` for verbose output.

--- a/scripts/node_ref_benchmark_server.mjs
+++ b/scripts/node_ref_benchmark_server.mjs
@@ -1,0 +1,26 @@
+import { pathToFileURL } from 'node:url'
+
+const modulePath = process.env.NODE_REF_SERVER_MODULE
+if (!modulePath) {
+  throw new Error('NODE_REF_SERVER_MODULE is required')
+}
+
+const { DurableStreamTestServer } = await import(pathToFileURL(modulePath).href)
+
+const port = Number(process.env.PORT || '4438')
+const host = process.env.HOST || '127.0.0.1'
+const mode = process.env.MODE || 'memory'
+const dataDir = mode === 'file' ? (process.env.DATA_DIR || '/tmp/node-ref-file-store') : undefined
+
+const server = new DurableStreamTestServer({ port, host, dataDir })
+await server.start()
+
+const shutdown = async () => {
+  await server.stop()
+  process.exit(0)
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
+
+setInterval(() => {}, 1 << 30)

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Shared benchmark lifecycle: start server, health-check, run vitest bench, stop.
+#
+# Usage:
+#   run_benchmark.sh <label> <host> <port> <health_path> <results_suffix> <server_cmd...>
+#
+# Environment:
+#   BENCHMARK_DIR          - directory containing benchmark.bench.mjs (required)
+#   BENCHMARK_VITEST_FLAGS - extra vitest flags (default: --silent=passed-only)
+
+set -euo pipefail
+
+LABEL="$1"; shift
+HOST="$1"; shift
+PORT="$1"; shift
+HEALTH_PATH="$1"; shift
+RESULTS_SUFFIX="$1"; shift
+# Remaining args are the server command
+
+BENCHMARK_DIR="${BENCHMARK_DIR:?BENCHMARK_DIR must be set}"
+VITEST_FLAGS="${BENCHMARK_VITEST_FLAGS:---silent=passed-only}"
+
+BASE_URL="http://${HOST}:${PORT}"
+HEALTH_URL="${BASE_URL}${HEALTH_PATH}"
+
+SERVER_PID=""
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+}
+trap cleanup EXIT INT TERM
+
+echo ""
+echo "=== Benchmark: ${LABEL} ==="
+
+"$@" & SERVER_PID=$!
+
+echo "Waiting for health check at ${HEALTH_URL}..."
+HEALTHY=0
+for _ in $(seq 1 30); do
+    if curl -s "$HEALTH_URL" > /dev/null 2>&1; then
+        HEALTHY=1
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Server for ${LABEL} exited before becoming healthy"
+        exit 1
+    fi
+    sleep 1
+done
+if [ "$HEALTHY" -ne 1 ]; then
+    echo "Server for ${LABEL} did not pass health check in time"
+    exit 1
+fi
+
+echo "Running benchmarks for ${LABEL}..."
+cd "$BENCHMARK_DIR" && BENCHMARK_URL="$BASE_URL" npx vitest bench --run $VITEST_FLAGS benchmark.bench.mjs
+RESULT=$?
+
+echo "Stopping server for ${LABEL}..."
+cleanup
+
+# Wait for port to free up
+for _ in $(seq 1 10); do
+    if curl -s "$HEALTH_URL" > /dev/null 2>&1; then
+        sleep 1
+    else
+        break
+    fi
+done
+
+if [ -f "$BENCHMARK_DIR/benchmark-results.json" ]; then
+    cp "$BENCHMARK_DIR/benchmark-results.json" "$BENCHMARK_DIR/benchmark-results-${RESULTS_SUFFIX}.json"
+    echo "Saved results to $BENCHMARK_DIR/benchmark-results-${RESULTS_SUFFIX}.json"
+fi
+
+exit "$RESULT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,38 @@
 use std::env;
 use std::time::Duration;
 
+/// Storage runtime mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageMode {
+    /// In-memory backend.
+    Memory,
+    /// File backend without fsync/fdatasync on every append.
+    FileFast,
+    /// File backend with fsync/fdatasync on every append.
+    FileDurable,
+}
+
+impl StorageMode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::FileFast => "file-fast",
+            Self::FileDurable => "file-durable",
+        }
+    }
+
+    #[must_use]
+    pub fn uses_file_backend(self) -> bool {
+        matches!(self, Self::FileFast | Self::FileDurable)
+    }
+
+    #[must_use]
+    pub fn sync_on_append(self) -> bool {
+        matches!(self, Self::FileDurable)
+    }
+}
+
 /// Server configuration
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -16,6 +48,10 @@ pub struct Config {
     pub long_poll_timeout: Duration,
     /// SSE idle close timeout in seconds (0 disables)
     pub sse_idle_close_secs: u64,
+    /// Selected storage mode
+    pub storage_mode: StorageMode,
+    /// Root directory for file-backed storage
+    pub storage_dir: String,
 }
 
 impl Config {
@@ -38,6 +74,7 @@ impl Config {
         let sse_idle_close_secs: u64 = get("SSE_IDLE_CLOSE_SECS")
             .and_then(|s| s.parse().ok())
             .unwrap_or(60);
+        let storage_mode = Self::parse_storage_mode(&get);
 
         Self {
             port: get("PORT").and_then(|s| s.parse().ok()).unwrap_or(4437),
@@ -50,7 +87,43 @@ impl Config {
             cors_origins: get("CORS_ORIGINS").unwrap_or_else(|| "*".to_string()),
             long_poll_timeout: Duration::from_secs(long_poll_secs),
             sse_idle_close_secs,
+            storage_mode,
+            storage_dir: get("STORAGE_DIR").unwrap_or_else(|| "./data/streams".to_string()),
         }
+    }
+
+    fn parse_storage_mode(get: &impl Fn(&str) -> Option<String>) -> StorageMode {
+        if let Some(mode) = get("STORAGE_MODE")
+            && let Some(parsed) = Self::parse_storage_mode_value(&mode)
+        {
+            return parsed;
+        }
+
+        // Backward-compatible fallback for legacy envs.
+        let backend = get("STORAGE_BACKEND").unwrap_or_else(|| "memory".to_string());
+        if backend.eq_ignore_ascii_case("file") {
+            let explicit_sync = get("FILE_STORAGE_SYNC_ON_APPEND").map(|v| Self::parse_bool(&v));
+            return if explicit_sync.unwrap_or(true) {
+                StorageMode::FileDurable
+            } else {
+                StorageMode::FileFast
+            };
+        }
+
+        StorageMode::Memory
+    }
+
+    fn parse_storage_mode_value(raw: &str) -> Option<StorageMode> {
+        match raw.to_ascii_lowercase().as_str() {
+            "memory" => Some(StorageMode::Memory),
+            "file" | "file-durable" | "durable" => Some(StorageMode::FileDurable),
+            "file-fast" | "fast" => Some(StorageMode::FileFast),
+            _ => None,
+        }
+    }
+
+    fn parse_bool(raw: &str) -> bool {
+        matches!(raw, "1" | "true" | "TRUE" | "True")
     }
 }
 
@@ -63,6 +136,8 @@ impl Default for Config {
             cors_origins: "*".to_string(),
             long_poll_timeout: Duration::from_secs(30),
             sse_idle_close_secs: 60,
+            storage_mode: StorageMode::Memory,
+            storage_dir: "./data/streams".to_string(),
         }
     }
 }
@@ -100,6 +175,8 @@ mod tests {
         assert_eq!(config.cors_origins, "*");
         assert_eq!(config.long_poll_timeout, Duration::from_secs(30));
         assert_eq!(config.sse_idle_close_secs, 60);
+        assert_eq!(config.storage_mode, StorageMode::Memory);
+        assert_eq!(config.storage_dir, "./data/streams");
     }
 
     #[test]
@@ -111,6 +188,8 @@ mod tests {
         assert_eq!(config.cors_origins, "*");
         assert_eq!(config.long_poll_timeout, Duration::from_secs(30));
         assert_eq!(config.sse_idle_close_secs, 60);
+        assert_eq!(config.storage_mode, StorageMode::Memory);
+        assert_eq!(config.storage_dir, "./data/streams");
     }
 
     #[test]
@@ -122,6 +201,8 @@ mod tests {
             ("CORS_ORIGINS", "https://example.com"),
             ("LONG_POLL_TIMEOUT_SECS", "5"),
             ("SSE_IDLE_CLOSE_SECS", "120"),
+            ("STORAGE_MODE", "file-fast"),
+            ("STORAGE_DIR", "/tmp/ds-store"),
         ]);
         let config = Config::from_lookup(get);
         assert_eq!(config.port, 8080);
@@ -130,6 +211,8 @@ mod tests {
         assert_eq!(config.cors_origins, "https://example.com");
         assert_eq!(config.long_poll_timeout, Duration::from_secs(5));
         assert_eq!(config.sse_idle_close_secs, 120);
+        assert_eq!(config.storage_mode, StorageMode::FileFast);
+        assert_eq!(config.storage_dir, "/tmp/ds-store");
     }
 
     #[test]
@@ -148,6 +231,7 @@ mod tests {
         assert_eq!(config.max_stream_bytes, 10 * 1024 * 1024);
         assert_eq!(config.long_poll_timeout, Duration::from_secs(30));
         assert_eq!(config.sse_idle_close_secs, 60);
+        assert_eq!(config.storage_mode, StorageMode::Memory);
     }
 
     #[test]
@@ -161,6 +245,7 @@ mod tests {
         assert_eq!(config.cors_origins, "*");
         assert_eq!(config.long_poll_timeout, Duration::from_secs(30));
         assert_eq!(config.sse_idle_close_secs, 60);
+        assert_eq!(config.storage_mode, StorageMode::Memory);
     }
 
     #[test]
@@ -175,6 +260,25 @@ mod tests {
         assert_eq!(via_env.cors_origins, via_lookup.cors_origins);
         assert_eq!(via_env.long_poll_timeout, via_lookup.long_poll_timeout);
         assert_eq!(via_env.sse_idle_close_secs, via_lookup.sse_idle_close_secs);
+        assert_eq!(via_env.storage_mode, via_lookup.storage_mode);
+        assert_eq!(via_env.storage_dir, via_lookup.storage_dir);
+    }
+
+    #[test]
+    fn test_storage_mode_legacy_env_uses_durable_default_for_file() {
+        let get = lookup(&[("STORAGE_BACKEND", "file")]);
+        let config = Config::from_lookup(get);
+        assert_eq!(config.storage_mode, StorageMode::FileDurable);
+    }
+
+    #[test]
+    fn test_storage_mode_legacy_env_allows_explicit_fast_override() {
+        let get = lookup(&[
+            ("STORAGE_BACKEND", "file"),
+            ("FILE_STORAGE_SYNC_ON_APPEND", "false"),
+        ]);
+        let config = Config::from_lookup(get);
+        assert_eq!(config.storage_mode, StorageMode::FileFast);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
-use durable_streams_reference::{config::Config, router, storage::memory::InMemoryStorage};
+use durable_streams_reference::{
+    config::Config,
+    router,
+    storage::{Storage, file::FileStorage, memory::InMemoryStorage},
+};
+use std::env;
 use std::sync::Arc;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -22,18 +27,36 @@ async fn main() {
         config.max_memory_bytes,
         config.max_stream_bytes
     );
+    let storage_backend = env::var("STORAGE_BACKEND").unwrap_or_else(|_| "memory".to_string());
+    tracing::info!("Storage backend: {}", storage_backend);
 
-    // Create storage
-    let storage = Arc::new(InMemoryStorage::new(
-        config.max_memory_bytes,
-        config.max_stream_bytes,
-    ));
+    if storage_backend.eq_ignore_ascii_case("file") {
+        let root_dir = env::var("STORAGE_DIR").unwrap_or_else(|_| "./data/streams".to_string());
+        let sync_on_append = env::var("FILE_STORAGE_SYNC_ON_APPEND")
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
+            .unwrap_or(false);
+        let storage = Arc::new(
+            FileStorage::new(
+                root_dir,
+                config.max_memory_bytes,
+                config.max_stream_bytes,
+                sync_on_append,
+            )
+            .unwrap_or_else(|e| panic!("Failed to initialize file storage: {e}")),
+        );
+        serve(storage, &config, &addr).await;
+    } else {
+        let storage = Arc::new(InMemoryStorage::new(
+            config.max_memory_bytes,
+            config.max_stream_bytes,
+        ));
+        serve(storage, &config, &addr).await;
+    }
+}
 
-    // Build router
-    let app = router::build_router(storage, &config);
-
-    // Bind and serve
-    let listener = tokio::net::TcpListener::bind(&addr)
+async fn serve<S: Storage + 'static>(storage: Arc<S>, config: &Config, addr: &str) {
+    let app = router::build_router(storage, config);
+    let listener = tokio::net::TcpListener::bind(addr)
         .await
         .unwrap_or_else(|e| panic!("Failed to bind to {addr}: {e}"));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use durable_streams_reference::{
     router,
     storage::{Storage, file::FileStorage, memory::InMemoryStorage},
 };
-use std::env;
 use std::sync::Arc;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -27,17 +26,18 @@ async fn main() {
         config.max_memory_bytes,
         config.max_stream_bytes
     );
-    let storage_backend = env::var("STORAGE_BACKEND").unwrap_or_else(|_| "memory".to_string());
-    tracing::info!("Storage backend: {}", storage_backend);
+    tracing::info!("Storage mode: {}", config.storage_mode.as_str());
 
-    if storage_backend.eq_ignore_ascii_case("file") {
-        let root_dir = env::var("STORAGE_DIR").unwrap_or_else(|_| "./data/streams".to_string());
-        let sync_on_append = env::var("FILE_STORAGE_SYNC_ON_APPEND")
-            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
-            .unwrap_or(false);
+    if config.storage_mode.uses_file_backend() {
+        let sync_on_append = config.storage_mode.sync_on_append();
+        tracing::info!(
+            "File storage dir: {}, sync on append: {}",
+            config.storage_dir,
+            sync_on_append
+        );
         let storage = Arc::new(
             FileStorage::new(
-                root_dir,
+                &config.storage_dir,
                 config.max_memory_bytes,
                 config.max_stream_bytes,
                 sync_on_append,

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -85,6 +85,10 @@ pub enum Error {
     /// Stream-Seq ordering violation (409)
     #[error("Stream-Seq ordering violation: last={last}, received={received}")]
     SeqOrderingViolation { last: String, received: String },
+
+    /// Storage backend I/O or serialization error (500)
+    #[error("Storage error: {0}")]
+    Storage(String),
 }
 
 impl Error {
@@ -113,6 +117,7 @@ impl Error {
             | Self::InvalidJson(_)
             | Self::EmptyBody
             | Self::InvalidHeader { .. } => 400,
+            Self::Storage(_) => 500,
         }
     }
 }

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -1,6 +1,7 @@
 use super::{
-    CreateStreamResult, CreateWithDataResult, Message, ProducerAppendResult, ReadResult, Storage,
-    StreamConfig, StreamMetadata,
+    CreateStreamResult, CreateWithDataResult, Message, NOTIFY_CHANNEL_CAPACITY,
+    ProducerAppendResult, ProducerCheck, ProducerState, ReadResult, Storage, StreamConfig,
+    StreamMetadata,
 };
 use crate::protocol::error::{Error, Result};
 use crate::protocol::offset::Offset;
@@ -16,27 +17,14 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
 
-/// Duration after which stale producer state is cleaned up (7 days).
-const PRODUCER_STATE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
-
-/// Broadcast channel capacity for long-poll/SSE notifications.
-const NOTIFY_CHANNEL_CAPACITY: usize = 16;
-
 /// Binary record header size: little-endian `u32` payload length.
-const RECORD_HEADER_BYTES: u64 = 4;
+const RECORD_HEADER_BYTES: usize = 4;
 
 #[derive(Debug, Clone)]
 struct MessageIndex {
     offset: Offset,
     file_pos: u64,
     byte_len: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ProducerState {
-    epoch: u64,
-    last_seq: u64,
-    updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -82,13 +70,6 @@ impl StreamEntry {
             dir,
         }
     }
-
-    fn cleanup_stale_producers(&mut self) {
-        let cutoff = Utc::now()
-            - chrono::TimeDelta::try_seconds(PRODUCER_STATE_TTL_SECS)
-                .expect("7 days fits in TimeDelta");
-        self.producers.retain(|_, state| state.updated_at > cutoff);
-    }
 }
 
 /// High-throughput file-backed storage.
@@ -98,6 +79,7 @@ impl StreamEntry {
 /// - In-memory offset/file index for fast reads
 /// - Stream-level write lock serializes appends and preserves monotonic offsets
 /// - Batched write per append call reduces syscall overhead
+#[allow(clippy::module_name_repetitions)]
 pub struct FileStorage {
     streams: RwLock<HashMap<String, Arc<RwLock<StreamEntry>>>>,
     total_bytes: RwLock<u64>,
@@ -108,6 +90,10 @@ pub struct FileStorage {
 }
 
 impl FileStorage {
+    /// # Errors
+    ///
+    /// Returns `Error::Storage` if the root directory cannot be created or
+    /// existing streams fail to load from disk.
     pub fn new(
         root_dir: impl Into<PathBuf>,
         max_total_bytes: u64,
@@ -134,6 +120,9 @@ impl FileStorage {
         Ok(storage)
     }
 
+    /// # Panics
+    ///
+    /// Panics if the internal `total_bytes` lock is poisoned.
     #[must_use]
     pub fn total_bytes(&self) -> u64 {
         *self.total_bytes.read().expect("total_bytes lock poisoned")
@@ -207,7 +196,7 @@ impl FileStorage {
             .len();
 
         let mut cursor = 0u64;
-        let mut header = [0u8; RECORD_HEADER_BYTES as usize];
+        let mut header = [0u8; RECORD_HEADER_BYTES];
 
         while cursor < file_len {
             file.seek(SeekFrom::Start(cursor))
@@ -221,7 +210,7 @@ impl FileStorage {
                 break;
             }
 
-            if read < RECORD_HEADER_BYTES as usize {
+            if read < RECORD_HEADER_BYTES {
                 file.set_len(cursor).map_err(|e| {
                     Error::Storage(format!("failed to truncate partial record: {e}"))
                 })?;
@@ -229,7 +218,7 @@ impl FileStorage {
             }
 
             let record_len = u64::from(u32::from_le_bytes(header));
-            let record_end = cursor + RECORD_HEADER_BYTES + record_len;
+            let record_end = cursor + RECORD_HEADER_BYTES as u64 + record_len;
 
             if record_end > file_len {
                 file.set_len(cursor).map_err(|e| {
@@ -240,7 +229,7 @@ impl FileStorage {
 
             index.push(MessageIndex {
                 offset: Offset::new(next_read_seq, next_byte_offset),
-                file_pos: cursor + RECORD_HEADER_BYTES,
+                file_pos: cursor + RECORD_HEADER_BYTES as u64,
                 byte_len: record_len,
             });
 
@@ -255,39 +244,16 @@ impl FileStorage {
         Ok((index, next_read_seq, next_byte_offset))
     }
 
-    fn is_expired(entry: &StreamEntry) -> bool {
-        if let Some(expires_at) = entry.config.expires_at {
-            Utc::now() >= expires_at
-        } else {
-            false
-        }
-    }
-
     fn get_stream(&self, name: &str) -> Option<Arc<RwLock<StreamEntry>>> {
         let streams = self.streams.read().expect("streams lock poisoned");
         streams.get(name).map(Arc::clone)
-    }
-
-    fn validate_seq(stream: &StreamEntry, seq: Option<&str>) -> Result<Option<String>> {
-        if let Some(new_seq) = seq {
-            if let Some(ref last) = stream.last_seq
-                && new_seq <= last.as_str()
-            {
-                return Err(Error::SeqOrderingViolation {
-                    last: last.clone(),
-                    received: new_seq.to_string(),
-                });
-            }
-            return Ok(Some(new_seq.to_string()));
-        }
-        Ok(None)
     }
 
     fn append_records(
         &self,
         name: &str,
         stream: &mut StreamEntry,
-        messages: Vec<Bytes>,
+        messages: &[Bytes],
     ) -> Result<()> {
         if messages.is_empty() {
             return Ok(());
@@ -297,7 +263,7 @@ impl FileStorage {
         let mut payload_bytes = 0u64;
         let mut sizes = Vec::with_capacity(messages.len());
 
-        for msg in &messages {
+        for msg in messages {
             let len = u64::try_from(msg.len()).unwrap_or(u64::MAX);
             if len > u64::from(u32::MAX) {
                 return Err(Error::InvalidHeader {
@@ -318,13 +284,10 @@ impl FileStorage {
             return Err(Error::StreamSizeLimitExceeded);
         }
 
-        let mut write_buf = Vec::with_capacity(
-            usize::try_from(
-                payload_bytes + (RECORD_HEADER_BYTES * u64::try_from(messages.len()).unwrap_or(0)),
-            )
-            .unwrap_or(0),
-        );
-        for msg in &messages {
+        let wire_overhead = RECORD_HEADER_BYTES.saturating_mul(messages.len());
+        let mut write_buf =
+            Vec::with_capacity(usize::try_from(payload_bytes).unwrap_or(0) + wire_overhead);
+        for msg in messages {
             let len = u32::try_from(msg.len()).unwrap_or(u32::MAX);
             write_buf.extend_from_slice(&len.to_le_bytes());
             write_buf.extend_from_slice(msg);
@@ -352,13 +315,13 @@ impl FileStorage {
             let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
             stream.index.push(MessageIndex {
                 offset,
-                file_pos: cursor + RECORD_HEADER_BYTES,
+                file_pos: cursor + RECORD_HEADER_BYTES as u64,
                 byte_len: len,
             });
             stream.next_read_seq += 1;
             stream.next_byte_offset += len;
             stream.total_bytes += len;
-            cursor += RECORD_HEADER_BYTES + len;
+            cursor += RECORD_HEADER_BYTES as u64 + len;
         }
 
         let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
@@ -456,7 +419,7 @@ impl FileStorage {
                 dir: path,
             };
 
-            if Self::is_expired(&entry) {
+            if super::is_stream_expired(&entry.config) {
                 Self::remove_stream_dir(&entry.dir)?;
                 continue;
             }
@@ -479,7 +442,7 @@ impl Storage for FileStorage {
         if let Some(stream_arc) = streams.get(name) {
             let stream = stream_arc.read().expect("stream lock poisoned");
 
-            if Self::is_expired(&stream) {
+            if super::is_stream_expired(&stream.config) {
                 let stream_bytes = stream.total_bytes;
                 let dir = stream.dir.clone();
                 drop(stream);
@@ -521,7 +484,7 @@ impl Storage for FileStorage {
 
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
@@ -529,17 +492,10 @@ impl Storage for FileStorage {
             return Err(Error::StreamClosed);
         }
 
-        let normalized_ct = content_type.to_lowercase();
-        let expected_ct = stream.config.content_type.to_lowercase();
-        if normalized_ct != expected_ct {
-            return Err(Error::ContentTypeMismatch {
-                expected: stream.config.content_type.clone(),
-                actual: content_type.to_string(),
-            });
-        }
+        super::validate_content_type(&stream.config.content_type, content_type)?;
 
         let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
-        self.append_records(name, &mut stream, vec![data])?;
+        self.append_records(name, &mut stream, &[data])?;
         Self::write_metadata_for(name, &stream)?;
         Ok(offset)
     }
@@ -564,7 +520,7 @@ impl Storage for FileStorage {
 
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
@@ -572,17 +528,10 @@ impl Storage for FileStorage {
             return Err(Error::StreamClosed);
         }
 
-        let normalized_ct = content_type.to_lowercase();
-        let expected_ct = stream.config.content_type.to_lowercase();
-        if normalized_ct != expected_ct {
-            return Err(Error::ContentTypeMismatch {
-                expected: stream.config.content_type.clone(),
-                actual: content_type.to_string(),
-            });
-        }
+        super::validate_content_type(&stream.config.content_type, content_type)?;
 
-        let pending_seq = Self::validate_seq(&stream, seq)?;
-        self.append_records(name, &mut stream, messages)?;
+        let pending_seq = super::validate_seq(stream.last_seq.as_deref(), seq)?;
+        self.append_records(name, &mut stream, &messages)?;
         if let Some(new_seq) = pending_seq {
             stream.last_seq = Some(new_seq);
         }
@@ -598,7 +547,7 @@ impl Storage for FileStorage {
 
         let stream = stream_arc.read().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
@@ -658,7 +607,7 @@ impl Storage for FileStorage {
 
         let stream = stream_arc.read().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
@@ -679,7 +628,7 @@ impl Storage for FileStorage {
 
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
@@ -705,72 +654,36 @@ impl Storage for FileStorage {
 
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
-        stream.cleanup_stale_producers();
+        super::cleanup_stale_producers(&mut stream.producers);
 
         if !messages.is_empty() {
-            let normalized_ct = content_type.to_lowercase();
-            let expected_ct = stream.config.content_type.to_lowercase();
-            if normalized_ct != expected_ct {
-                return Err(Error::ContentTypeMismatch {
-                    expected: stream.config.content_type.clone(),
-                    actual: content_type.to_string(),
-                });
-            }
+            super::validate_content_type(&stream.config.content_type, content_type)?;
         }
 
         let now = Utc::now();
 
-        if let Some(state) = stream.producers.get(producer.id.as_str()) {
-            if producer.epoch < state.epoch {
-                return Err(Error::EpochFenced {
-                    current: state.epoch,
-                    received: producer.epoch,
-                });
-            }
-
-            if producer.epoch == state.epoch && producer.seq <= state.last_seq {
+        match super::check_producer(
+            stream.producers.get(producer.id.as_str()),
+            producer,
+            stream.closed,
+        )? {
+            ProducerCheck::Accept => {}
+            ProducerCheck::Duplicate { epoch, seq } => {
                 return Ok(ProducerAppendResult::Duplicate {
-                    epoch: state.epoch,
-                    seq: state.last_seq,
+                    epoch,
+                    seq,
                     next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
                     closed: stream.closed,
                 });
             }
-
-            if stream.closed {
-                return Err(Error::StreamClosed);
-            }
-
-            if producer.epoch > state.epoch {
-                if producer.seq != 0 {
-                    return Err(Error::InvalidProducerState(
-                        "new epoch must start at seq 0".to_string(),
-                    ));
-                }
-            } else if producer.seq > state.last_seq + 1 {
-                return Err(Error::SequenceGap {
-                    expected: state.last_seq + 1,
-                    actual: producer.seq,
-                });
-            }
-        } else {
-            if stream.closed {
-                return Err(Error::StreamClosed);
-            }
-            if producer.seq != 0 {
-                return Err(Error::SequenceGap {
-                    expected: 0,
-                    actual: producer.seq,
-                });
-            }
         }
 
-        let pending_seq = Self::validate_seq(&stream, seq)?;
-        self.append_records(name, &mut stream, messages)?;
+        let pending_seq = super::validate_seq(stream.last_seq.as_deref(), seq)?;
+        self.append_records(name, &mut stream, &messages)?;
 
         if let Some(new_seq) = pending_seq {
             stream.last_seq = Some(new_seq);
@@ -810,7 +723,7 @@ impl Storage for FileStorage {
         if let Some(stream_arc) = streams.get(name) {
             let stream = stream_arc.read().expect("stream lock poisoned");
 
-            if Self::is_expired(&stream) {
+            if super::is_stream_expired(&stream.config) {
                 let stream_bytes = stream.total_bytes;
                 let dir = stream.dir.clone();
                 drop(stream);
@@ -844,7 +757,7 @@ impl Storage for FileStorage {
         let mut entry = StreamEntry::new(config, file, dir);
 
         if !messages.is_empty() {
-            self.append_records(name, &mut entry, messages)?;
+            self.append_records(name, &mut entry, &messages)?;
         }
         if should_close {
             entry.closed = true;
@@ -867,7 +780,7 @@ impl Storage for FileStorage {
         let streams = self.streams.read().expect("streams lock poisoned");
         if let Some(stream_arc) = streams.get(name) {
             let stream = stream_arc.read().expect("stream lock poisoned");
-            !Self::is_expired(&stream)
+            !super::is_stream_expired(&stream.config)
         } else {
             false
         }
@@ -877,7 +790,7 @@ impl Storage for FileStorage {
         let stream_arc = self.get_stream(name)?;
         let stream = stream_arc.read().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return None;
         }
 
@@ -902,30 +815,758 @@ mod tests {
             .expect("file storage should initialize")
     }
 
+    fn producer(id: &str, epoch: u64, seq: u64) -> ProducerHeaders {
+        ProducerHeaders {
+            id: id.to_string(),
+            epoch,
+            seq,
+        }
+    }
+
     #[test]
-    fn test_append_and_read_roundtrip() {
+    fn test_create_stream() {
         let storage = test_storage();
         let config = StreamConfig::new("text/plain".to_string());
 
+        let result = storage.create_stream("test", config.clone()).unwrap();
+        assert_eq!(result, CreateStreamResult::Created);
+        assert!(storage.exists("test"));
+
+        let result = storage.create_stream("test", config).unwrap();
+        assert_eq!(result, CreateStreamResult::AlreadyExists);
+
+        let different_config = StreamConfig::new("application/json".to_string());
+        assert!(matches!(
+            storage.create_stream("test", different_config),
+            Err(Error::ConfigMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_append_and_read() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let data1 = Bytes::from("hello");
+        let offset1 = storage.append("test", data1.clone(), "text/plain").unwrap();
+
+        let data2 = Bytes::from("world");
+        let offset2 = storage.append("test", data2.clone(), "text/plain").unwrap();
+
+        assert!(offset1 < offset2);
+
+        let result = storage.read("test", &Offset::start()).unwrap();
+        assert_eq!(result.messages.len(), 2);
+        assert_eq!(result.messages[0].data, data1);
+        assert_eq!(result.messages[1].data, data2);
+        assert!(result.at_tail);
+    }
+
+    #[test]
+    fn test_offset_monotonicity() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let mut offsets = Vec::new();
+        for i in 0..10 {
+            let data = Bytes::from(format!("message {i}"));
+            let offset = storage.append("test", data, "text/plain").unwrap();
+            offsets.push(offset);
+        }
+
+        for i in 1..offsets.len() {
+            assert!(offsets[i - 1] < offsets[i], "Offset monotonicity violated");
+        }
+    }
+
+    #[test]
+    fn test_read_from_offset() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let offset1 = storage
+            .append("test", Bytes::from("msg1"), "text/plain")
+            .unwrap();
+        let offset2 = storage
+            .append("test", Bytes::from("msg2"), "text/plain")
+            .unwrap();
+        let _offset3 = storage
+            .append("test", Bytes::from("msg3"), "text/plain")
+            .unwrap();
+
+        let result = storage.read("test", &offset2).unwrap();
+        assert_eq!(result.messages.len(), 2);
+        assert_eq!(result.messages[0].data, Bytes::from("msg2"));
+        assert_eq!(result.messages[1].data, Bytes::from("msg3"));
+
+        let result = storage.read("test", &offset1).unwrap();
+        assert_eq!(result.messages.len(), 3);
+    }
+
+    #[test]
+    fn test_read_sentinels() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
         storage
-            .create_stream("test", config)
-            .expect("stream should be created");
+            .append("test", Bytes::from("msg1"), "text/plain")
+            .unwrap();
 
-        let first = storage
-            .append("test", Bytes::from("hello"), "text/plain")
-            .expect("append should succeed");
-        let second = storage
-            .append("test", Bytes::from("world"), "text/plain")
-            .expect("append should succeed");
+        let result = storage.read("test", &Offset::now()).unwrap();
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.at_tail);
 
-        assert!(first < second);
+        let result = storage.read("test", &Offset::start()).unwrap();
+        assert_eq!(result.messages.len(), 1);
+    }
 
-        let read = storage
-            .read("test", &Offset::start())
-            .expect("read should succeed");
-        assert_eq!(read.messages.len(), 2);
-        assert_eq!(read.messages[0].data, Bytes::from("hello"));
-        assert_eq!(read.messages[1].data, Bytes::from("world"));
+    #[test]
+    fn test_stream_closed() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage.close_stream("test").unwrap();
+
+        assert!(matches!(
+            storage.append("test", Bytes::from("data"), "text/plain"),
+            Err(Error::StreamClosed)
+        ));
+
+        let result = storage.read("test", &Offset::start()).unwrap();
+        assert!(result.closed);
+    }
+
+    #[test]
+    fn test_content_type_mismatch() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        assert!(matches!(
+            storage.append("test", Bytes::from("data"), "application/json"),
+            Err(Error::ContentTypeMismatch { .. })
+        ));
+
+        // Case-insensitive match should work
+        storage
+            .append("test", Bytes::from("data"), "TEXT/PLAIN")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_memory_limits() {
+        let root = test_storage_dir();
+        let storage = FileStorage::new(root, 100, 50, false).unwrap();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test1", config.clone()).unwrap();
+        storage.create_stream("test2", config).unwrap();
+
+        storage
+            .append("test1", Bytes::from(vec![0u8; 50]), "text/plain")
+            .unwrap();
+
+        assert!(matches!(
+            storage.append("test1", Bytes::from(vec![0u8; 10]), "text/plain"),
+            Err(Error::StreamSizeLimitExceeded)
+        ));
+
+        storage
+            .append("test2", Bytes::from(vec![0u8; 40]), "text/plain")
+            .unwrap();
+
+        assert!(matches!(
+            storage.append("test2", Bytes::from(vec![0u8; 20]), "text/plain"),
+            Err(Error::MemoryLimitExceeded)
+        ));
+    }
+
+    #[test]
+    fn test_batch_append_does_not_advance_stream_seq_on_failed_commit() {
+        let root = test_storage_dir();
+        let storage = FileStorage::new(root, 1024, 8, false).unwrap();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let oversized = vec![Bytes::from(vec![0_u8; 9])];
+        let err = storage.batch_append("test", oversized, "text/plain", Some("s1"));
+        assert!(matches!(err, Err(Error::StreamSizeLimitExceeded)));
+
+        let retry = vec![Bytes::from("ok")];
+        let result = storage.batch_append("test", retry, "text/plain", Some("s1"));
+        assert!(result.is_ok(), "retry with same seq should be accepted");
+    }
+
+    #[test]
+    fn test_producer_append_does_not_advance_stream_seq_on_failed_commit() {
+        let root = test_storage_dir();
+        let storage = FileStorage::new(root, 1024, 8, false).unwrap();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let oversized = vec![Bytes::from(vec![0_u8; 9])];
+        let err = storage.append_with_producer(
+            "test",
+            oversized,
+            "text/plain",
+            &producer("p1", 0, 0),
+            false,
+            Some("s1"),
+        );
+        assert!(matches!(err, Err(Error::StreamSizeLimitExceeded)));
+
+        let retry = storage.append_with_producer(
+            "test",
+            vec![Bytes::from("ok")],
+            "text/plain",
+            &producer("p1", 0, 0),
+            false,
+            Some("s1"),
+        );
+        assert!(
+            matches!(retry, Ok(ProducerAppendResult::Accepted { .. })),
+            "retry with same producer seq and stream seq should succeed"
+        );
+    }
+
+    #[test]
+    fn test_create_with_data_rolls_back_on_memory_limit() {
+        let root = test_storage_dir();
+        let storage = FileStorage::new(root, 1024, 8, false).unwrap();
+        let config = StreamConfig::new("text/plain".to_string());
+        let oversized = vec![Bytes::from(vec![0_u8; 9])];
+
+        let err = storage.create_stream_with_data("test", config, oversized, false);
+        assert!(matches!(err, Err(Error::StreamSizeLimitExceeded)));
+        assert!(
+            !storage.exists("test"),
+            "stream must not exist after failed create"
+        );
+    }
+
+    #[test]
+    fn test_create_with_data_closed_is_atomic() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string()).with_created_closed(true);
+
+        let result = storage
+            .create_stream_with_data("test", config, vec![], true)
+            .unwrap();
+        assert_eq!(result.status, CreateStreamResult::Created);
+        assert!(result.closed, "stream must be closed in result snapshot");
+
+        let meta = storage.head("test").unwrap();
+        assert!(meta.closed, "stream must be closed via head()");
+
+        assert!(matches!(
+            storage.append("test", Bytes::from("data"), "text/plain"),
+            Err(Error::StreamClosed)
+        ));
+    }
+
+    #[test]
+    fn test_create_with_data_appends_and_closes() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string()).with_created_closed(true);
+        let messages = vec![Bytes::from("hello"), Bytes::from("world")];
+
+        let result = storage
+            .create_stream_with_data("test", config, messages, true)
+            .unwrap();
+        assert_eq!(result.status, CreateStreamResult::Created);
+        assert!(result.closed);
+
+        let meta = storage.head("test").unwrap();
+        assert_eq!(meta.message_count, 2);
+        assert!(meta.closed);
+    }
+
+    #[test]
+    fn test_create_with_data_idempotent_ignores_body() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+
+        let r1 = storage
+            .create_stream_with_data("test", config.clone(), vec![Bytes::from("a")], false)
+            .unwrap();
+        assert_eq!(r1.status, CreateStreamResult::Created);
+
+        let r2 = storage
+            .create_stream_with_data("test", config, vec![Bytes::from("b")], false)
+            .unwrap();
+        assert_eq!(r2.status, CreateStreamResult::AlreadyExists);
+
+        let meta = storage.head("test").unwrap();
+        assert_eq!(meta.message_count, 1);
+    }
+
+    #[test]
+    fn test_delete() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append("test", Bytes::from(vec![0u8; 100]), "text/plain")
+            .unwrap();
+
+        let bytes_before = storage.total_bytes();
+        assert!(bytes_before >= 100);
+
+        storage.delete("test").unwrap();
+        assert!(!storage.exists("test"));
+
+        let bytes_after = storage.total_bytes();
+        assert_eq!(bytes_after, 0);
+
+        assert!(matches!(storage.delete("test"), Err(Error::NotFound(_))));
+    }
+
+    #[test]
+    fn test_delete_removes_files() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+        storage
+            .append("test", Bytes::from("data"), "text/plain")
+            .unwrap();
+
+        let dir = storage.stream_dir_for_name("test");
+        assert!(dir.exists(), "stream directory should exist before delete");
+
+        storage.delete("test").unwrap();
+        assert!(
+            !dir.exists(),
+            "stream directory should be removed after delete"
+        );
+    }
+
+    #[test]
+    fn test_head() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append("test", Bytes::from(vec![0u8; 50]), "text/plain")
+            .unwrap();
+        storage
+            .append("test", Bytes::from(vec![0u8; 30]), "text/plain")
+            .unwrap();
+
+        let metadata = storage.head("test").unwrap();
+        assert_eq!(metadata.config.content_type, "text/plain");
+        assert_eq!(metadata.message_count, 2);
+        assert_eq!(metadata.total_bytes, 80);
+        assert!(!metadata.closed);
+
+        storage.close_stream("test").unwrap();
+        let metadata = storage.head("test").unwrap();
+        assert!(metadata.closed);
+    }
+
+    #[test]
+    fn test_producer_basic_append() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let result = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("hello")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            result,
+            ProducerAppendResult::Accepted {
+                epoch: 0,
+                seq: 0,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_producer_sequential_appends() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        for s in 0..3 {
+            let result = storage
+                .append_with_producer(
+                    "test",
+                    vec![Bytes::from(format!("msg{s}"))],
+                    "text/plain",
+                    &producer("p1", 0, s),
+                    false,
+                    None,
+                )
+                .unwrap();
+            assert!(matches!(
+                result,
+                ProducerAppendResult::Accepted { epoch: 0, seq, .. } if seq == s
+            ));
+        }
+
+        let metadata = storage.head("test").unwrap();
+        assert_eq!(metadata.message_count, 3);
+    }
+
+    #[test]
+    fn test_producer_duplicate_detection() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("hello")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        let result = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("hello")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            result,
+            ProducerAppendResult::Duplicate {
+                epoch: 0,
+                seq: 0,
+                ..
+            }
+        ));
+
+        let metadata = storage.head("test").unwrap();
+        assert_eq!(metadata.message_count, 1);
+    }
+
+    #[test]
+    fn test_producer_sequence_gap() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("msg0")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        let err = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("msg2")],
+                "text/plain",
+                &producer("p1", 0, 5),
+                false,
+                None,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::SequenceGap {
+                expected: 1,
+                actual: 5
+            }
+        ));
+    }
+
+    #[test]
+    fn test_producer_epoch_fencing() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("msg")],
+                "text/plain",
+                &producer("p1", 1, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        let err = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("zombie")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                false,
+                None,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::EpochFenced {
+                current: 1,
+                received: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn test_producer_epoch_bump_resets_seq() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        for seq in 0..3 {
+            storage
+                .append_with_producer(
+                    "test",
+                    vec![Bytes::from(format!("e0s{seq}"))],
+                    "text/plain",
+                    &producer("p1", 0, seq),
+                    false,
+                    None,
+                )
+                .unwrap();
+        }
+
+        let result = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("e1s0")],
+                "text/plain",
+                &producer("p1", 1, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            result,
+            ProducerAppendResult::Accepted {
+                epoch: 1,
+                seq: 0,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_producer_epoch_bump_with_nonzero_seq() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("msg")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        let err = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("bad")],
+                "text/plain",
+                &producer("p1", 1, 5),
+                false,
+                None,
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, Error::InvalidProducerState(_)));
+    }
+
+    #[test]
+    fn test_producer_close_with_append() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let result = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("final")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                true,
+                None,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            result,
+            ProducerAppendResult::Accepted {
+                epoch: 0,
+                seq: 0,
+                closed: true,
+                ..
+            }
+        ));
+
+        let metadata = storage.head("test").unwrap();
+        assert!(metadata.closed);
+        assert_eq!(metadata.message_count, 1);
+    }
+
+    #[test]
+    fn test_producer_multiple_producers() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("a0")],
+                "text/plain",
+                &producer("a", 0, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("b0")],
+                "text/plain",
+                &producer("b", 0, 0),
+                false,
+                None,
+            )
+            .unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("a1")],
+                "text/plain",
+                &producer("a", 0, 1),
+                false,
+                None,
+            )
+            .unwrap();
+
+        let metadata = storage.head("test").unwrap();
+        assert_eq!(metadata.message_count, 3);
+    }
+
+    #[test]
+    fn test_producer_closed_stream_returns_closed_not_gap() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("final")],
+                "text/plain",
+                &producer("p1", 0, 0),
+                true,
+                None,
+            )
+            .unwrap();
+
+        let err = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("more")],
+                "text/plain",
+                &producer("p1", 0, 5),
+                false,
+                None,
+            )
+            .unwrap_err();
+
+        assert!(
+            matches!(err, Error::StreamClosed),
+            "Closed stream should return StreamClosed even with gap seq, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_producer_new_with_nonzero_seq_is_gap() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let err = storage
+            .append_with_producer(
+                "test",
+                vec![Bytes::from("bad")],
+                "text/plain",
+                &producer("p1", 0, 3),
+                false,
+                None,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::SequenceGap {
+                expected: 0,
+                actual: 3
+            }
+        ));
+    }
+
+    #[test]
+    fn test_not_found() {
+        let storage = test_storage();
+
+        assert!(matches!(
+            storage.append("nonexistent", Bytes::from("data"), "text/plain"),
+            Err(Error::NotFound(_))
+        ));
+
+        assert!(matches!(
+            storage.read("nonexistent", &Offset::start()),
+            Err(Error::NotFound(_))
+        ));
+
+        assert!(matches!(
+            storage.head("nonexistent"),
+            Err(Error::NotFound(_))
+        ));
+
+        assert!(matches!(
+            storage.close_stream("nonexistent"),
+            Err(Error::NotFound(_))
+        ));
     }
 
     #[test]
@@ -957,5 +1598,100 @@ mod tests {
         assert_eq!(read.messages.len(), 2);
         assert_eq!(read.messages[0].data, Bytes::from("event-1"));
         assert_eq!(read.messages[1].data, Bytes::from("event-2"));
+    }
+
+    #[test]
+    fn test_restore_closed_stream_from_disk() {
+        let root = test_storage_dir();
+        let config = StreamConfig::new("text/plain".to_string());
+
+        {
+            let storage = FileStorage::new(root.clone(), 1024 * 1024, 100 * 1024, false).unwrap();
+            storage.create_stream("s", config.clone()).unwrap();
+            storage
+                .append("s", Bytes::from("data"), "text/plain")
+                .unwrap();
+            storage.close_stream("s").unwrap();
+        }
+
+        let restored = FileStorage::new(root, 1024 * 1024, 100 * 1024, false).unwrap();
+        let meta = restored.head("s").unwrap();
+        assert!(meta.closed);
+        assert_eq!(meta.message_count, 1);
+
+        assert!(matches!(
+            restored.append("s", Bytes::from("more"), "text/plain"),
+            Err(Error::StreamClosed)
+        ));
+    }
+
+    #[test]
+    fn test_partial_record_truncation_on_recovery() {
+        let root = test_storage_dir();
+        let config = StreamConfig::new("text/plain".to_string());
+
+        {
+            let storage = FileStorage::new(root.clone(), 1024 * 1024, 100 * 1024, false).unwrap();
+            storage.create_stream("s", config.clone()).unwrap();
+            storage
+                .append("s", Bytes::from("good"), "text/plain")
+                .unwrap();
+        }
+
+        // Append partial garbage to the data log (incomplete record header)
+        let encoded = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode("s".as_bytes());
+        let log_path = root.join(&encoded).join("data.log");
+        let mut f = OpenOptions::new().append(true).open(&log_path).unwrap();
+        // Write a 2-byte partial header (less than the 4-byte record header)
+        f.write_all(&[0xFF, 0xFF]).unwrap();
+        drop(f);
+
+        let restored = FileStorage::new(root, 1024 * 1024, 100 * 1024, false).unwrap();
+        let read = restored.read("s", &Offset::start()).unwrap();
+        assert_eq!(read.messages.len(), 1);
+        assert_eq!(read.messages[0].data, Bytes::from("good"));
+    }
+
+    #[test]
+    fn test_concurrent_appends_monotonicity() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let storage = Arc::new(test_storage());
+        let config = StreamConfig::new("text/plain".to_string());
+        storage.create_stream("test", config).unwrap();
+
+        let mut handles = vec![];
+        for thread_id in 0..5 {
+            let storage_clone = Arc::clone(&storage);
+            let handle = thread::spawn(move || {
+                let mut offsets = Vec::new();
+                for i in 0..20 {
+                    let data = Bytes::from(format!("thread {thread_id} msg {i}"));
+                    let offset = storage_clone.append("test", data, "text/plain").unwrap();
+                    offsets.push(offset);
+                }
+                offsets
+            });
+            handles.push(handle);
+        }
+
+        let mut all_offsets = Vec::new();
+        for handle in handles {
+            let offsets = handle.join().unwrap();
+            all_offsets.extend(offsets);
+        }
+
+        all_offsets.sort();
+        for i in 1..all_offsets.len() {
+            assert_ne!(
+                all_offsets[i - 1],
+                all_offsets[i],
+                "Duplicate offset detected"
+            );
+        }
+
+        let metadata = storage.head("test").unwrap();
+        assert_eq!(metadata.message_count, 100);
     }
 }

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -16,6 +16,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
+use tracing::warn;
 
 /// Binary record header size: little-endian `u32` payload length.
 const RECORD_HEADER_BYTES: usize = 4;
@@ -255,6 +256,11 @@ impl FileStorage {
         Ok((index, next_read_seq, next_byte_offset))
     }
 
+    fn rollback_total_bytes(&self, bytes: u64) {
+        let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+        *total = total.saturating_sub(bytes);
+    }
+
     fn get_stream(&self, name: &str) -> Option<Arc<RwLock<StreamEntry>>> {
         let streams = self.streams.read().expect("streams lock poisoned");
         streams.get(name).map(Arc::clone)
@@ -287,12 +293,18 @@ impl FileStorage {
             sizes.push(len);
         }
 
-        let current_total = *self.total_bytes.read().expect("total_bytes lock poisoned");
-        if current_total + total_batch_bytes > self.max_total_bytes {
-            return Err(Error::MemoryLimitExceeded);
-        }
-        if stream.total_bytes + total_batch_bytes > self.max_stream_bytes {
-            return Err(Error::StreamSizeLimitExceeded);
+        // Check-and-reserve global limit atomically under a single write lock
+        // to prevent concurrent appends on different streams from exceeding it.
+        // Global check comes first to preserve error precedence.
+        {
+            let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+            if *total + total_batch_bytes > self.max_total_bytes {
+                return Err(Error::MemoryLimitExceeded);
+            }
+            if stream.total_bytes + total_batch_bytes > self.max_stream_bytes {
+                return Err(Error::StreamSizeLimitExceeded);
+            }
+            *total += total_batch_bytes;
         }
 
         let wire_overhead = RECORD_HEADER_BYTES.saturating_mul(messages.len());
@@ -304,21 +316,30 @@ impl FileStorage {
             write_buf.extend_from_slice(msg);
         }
 
-        let before_len = stream
-            .file
-            .metadata()
-            .map_err(|e| Error::Storage(format!("failed to stat stream log before append: {e}")))?
-            .len();
+        let before_len = match stream.file.metadata() {
+            Ok(m) => m.len(),
+            Err(e) => {
+                self.rollback_total_bytes(total_batch_bytes);
+                return Err(Error::Storage(format!(
+                    "failed to stat stream log before append: {e}"
+                )));
+            }
+        };
 
-        stream
-            .file
-            .write_all(&write_buf)
-            .map_err(|e| Error::Storage(format!("failed to append stream log for {name}: {e}")))?;
+        if let Err(e) = stream.file.write_all(&write_buf) {
+            self.rollback_total_bytes(total_batch_bytes);
+            return Err(Error::Storage(format!(
+                "failed to append stream log for {name}: {e}"
+            )));
+        }
 
-        if self.sync_on_append {
-            stream.file.sync_data().map_err(|e| {
-                Error::Storage(format!("failed to sync stream log for {name}: {e}"))
-            })?;
+        if self.sync_on_append
+            && let Err(e) = stream.file.sync_data()
+        {
+            self.rollback_total_bytes(total_batch_bytes);
+            return Err(Error::Storage(format!(
+                "failed to sync stream log for {name}: {e}"
+            )));
         }
 
         let mut cursor = before_len;
@@ -334,9 +355,6 @@ impl FileStorage {
             stream.total_bytes += len;
             cursor += RECORD_HEADER_BYTES as u64 + len;
         }
-
-        let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
-        *total += total_batch_bytes;
 
         let _ = stream.notify.send(());
         Ok(())
@@ -511,7 +529,10 @@ impl Storage for FileStorage {
 
         let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
         self.append_records(name, &mut stream, &[data])?;
-        Self::write_metadata_for(name, &stream)?;
+        // Data is committed to the log; metadata write failure is non-fatal
+        if let Err(e) = Self::write_metadata_for(name, &stream) {
+            warn!(%e, stream = name, "metadata persist failed after committed append");
+        }
         Ok(offset)
     }
 
@@ -550,7 +571,10 @@ impl Storage for FileStorage {
         if let Some(new_seq) = pending_seq {
             stream.last_seq = Some(new_seq);
         }
-        Self::write_metadata_for(name, &stream)?;
+        // Data is committed to the log; metadata write failure is non-fatal
+        if let Err(e) = Self::write_metadata_for(name, &stream) {
+            warn!(%e, stream = name, "metadata persist failed after committed batch append");
+        }
 
         Ok(Offset::new(stream.next_read_seq, stream.next_byte_offset))
     }
@@ -716,7 +740,10 @@ impl Storage for FileStorage {
             },
         );
 
-        Self::write_metadata_for(name, &stream)?;
+        // Data is committed to the log; metadata write failure is non-fatal
+        if let Err(e) = Self::write_metadata_for(name, &stream) {
+            warn!(%e, stream = name, "metadata persist failed after committed producer append");
+        }
 
         Ok(ProducerAppendResult::Accepted {
             epoch: producer.epoch,
@@ -818,11 +845,12 @@ mod tests {
     use super::*;
 
     fn test_storage_dir() -> PathBuf {
-        let stamp = Utc::now()
-            .timestamp_nanos_opt()
-            .unwrap_or_default()
-            .to_string();
-        std::env::temp_dir().join(format!("ds-file-storage-test-{stamp}"))
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let stamp = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        std::env::temp_dir().join(format!("ds-file-storage-test-{stamp}-{pid}-{seq}"))
     }
 
     fn test_storage() -> FileStorage {

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -87,6 +87,7 @@ pub struct FileStorage {
     max_total_bytes: u64,
     max_stream_bytes: u64,
     root_dir: PathBuf,
+    root_dir_canonical: PathBuf,
     sync_on_append: bool,
 }
 
@@ -109,12 +110,20 @@ impl FileStorage {
             ))
         })?;
 
+        let root_dir_canonical = fs::canonicalize(&root_dir).map_err(|e| {
+            Error::Storage(format!(
+                "failed to canonicalize storage directory {}: {e}",
+                root_dir.display()
+            ))
+        })?;
+
         let storage = Self {
             streams: RwLock::new(HashMap::new()),
             total_bytes: RwLock::new(0),
             max_total_bytes,
             max_stream_bytes,
             root_dir,
+            root_dir_canonical,
             sync_on_append,
         };
         storage.load_existing_streams()?;
@@ -136,6 +145,14 @@ impl FileStorage {
     /// as defense in depth.
     fn stream_dir_for_name(&self, name: &str) -> Result<PathBuf> {
         let encoded = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(name.as_bytes());
+        if !encoded
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(Error::Storage(
+                "encoded stream directory contains invalid characters".to_string(),
+            ));
+        }
         let dir = self.root_dir.join(&encoded);
         if !dir.starts_with(&self.root_dir) {
             return Err(Error::Storage(format!(
@@ -143,6 +160,64 @@ impl FileStorage {
             )));
         }
         Ok(dir)
+    }
+
+    fn validate_stream_dir(&self, dir: &Path) -> Result<()> {
+        if !dir.starts_with(&self.root_dir) {
+            return Err(Error::Storage(format!(
+                "path escapes storage root: {}",
+                dir.display()
+            )));
+        }
+
+        let rel = dir.strip_prefix(&self.root_dir).map_err(|e| {
+            Error::Storage(format!(
+                "failed to validate storage path {}: {e}",
+                dir.display()
+            ))
+        })?;
+        if rel.components().count() != 1 {
+            return Err(Error::Storage(format!(
+                "invalid stream path depth: {}",
+                dir.display()
+            )));
+        }
+
+        if dir.exists() {
+            let metadata = fs::symlink_metadata(dir).map_err(|e| {
+                Error::Storage(format!(
+                    "failed to stat stream directory {}: {e}",
+                    dir.display()
+                ))
+            })?;
+            if metadata.file_type().is_symlink() {
+                return Err(Error::Storage(format!(
+                    "stream directory cannot be a symlink: {}",
+                    dir.display()
+                )));
+            }
+            if !metadata.is_dir() {
+                return Err(Error::Storage(format!(
+                    "stream path is not a directory: {}",
+                    dir.display()
+                )));
+            }
+
+            let canonical = fs::canonicalize(dir).map_err(|e| {
+                Error::Storage(format!(
+                    "failed to canonicalize stream directory {}: {e}",
+                    dir.display()
+                ))
+            })?;
+            if !canonical.starts_with(&self.root_dir_canonical) {
+                return Err(Error::Storage(format!(
+                    "stream directory resolves outside storage root: {}",
+                    dir.display()
+                )));
+            }
+        }
+
+        Ok(())
     }
 
     fn data_log_path(dir: &Path) -> PathBuf {
@@ -153,7 +228,8 @@ impl FileStorage {
         dir.join("meta.json")
     }
 
-    fn write_metadata_for(name: &str, entry: &StreamEntry) -> Result<()> {
+    fn write_metadata_for(&self, name: &str, entry: &StreamEntry) -> Result<()> {
+        self.validate_stream_dir(&entry.dir)?;
         let meta = StreamMeta {
             name: name.to_string(),
             config: entry.config.clone(),
@@ -185,7 +261,8 @@ impl FileStorage {
         Ok(())
     }
 
-    fn open_stream_file(dir: &Path) -> Result<File> {
+    fn open_stream_file(&self, dir: &Path) -> Result<File> {
+        self.validate_stream_dir(dir)?;
         let path = Self::data_log_path(dir);
         OpenOptions::new()
             .create(true)
@@ -382,7 +459,8 @@ impl FileStorage {
         Ok(messages)
     }
 
-    fn remove_stream_dir(dir: &Path) -> Result<()> {
+    fn remove_stream_dir(&self, dir: &Path) -> Result<()> {
+        self.validate_stream_dir(dir)?;
         fs::remove_dir_all(dir).map_err(|e| {
             Error::Storage(format!(
                 "failed to remove stream directory {}: {e}",
@@ -409,8 +487,7 @@ impl FileStorage {
             if !path.is_dir() {
                 continue;
             }
-            // Skip entries that escape root_dir (e.g. symlinks pointing outside)
-            if !path.starts_with(&self.root_dir) {
+            if self.validate_stream_dir(&path).is_err() {
                 continue;
             }
 
@@ -432,7 +509,7 @@ impl FileStorage {
                 ))
             })?;
 
-            let mut file = Self::open_stream_file(&path)?;
+            let mut file = self.open_stream_file(&path)?;
             let (index, next_read_seq, next_byte_offset) = Self::rebuild_index(&mut file)?;
             let total_bytes = next_byte_offset;
 
@@ -453,7 +530,7 @@ impl FileStorage {
             };
 
             if super::is_stream_expired(&entry.config) {
-                Self::remove_stream_dir(&entry.dir)?;
+                self.remove_stream_dir(&entry.dir)?;
                 continue;
             }
 
@@ -485,7 +562,7 @@ impl Storage for FileStorage {
                 *total = total.saturating_sub(stream_bytes);
                 drop(total);
 
-                Self::remove_stream_dir(&dir)?;
+                self.remove_stream_dir(&dir)?;
             } else if stream.config == config {
                 return Ok(CreateStreamResult::AlreadyExists);
             } else {
@@ -501,10 +578,11 @@ impl Storage for FileStorage {
             ))
         })?;
 
-        let file = Self::open_stream_file(&dir)?;
+        self.validate_stream_dir(&dir)?;
+        let file = self.open_stream_file(&dir)?;
         let entry = StreamEntry::new(config, file, dir);
 
-        Self::write_metadata_for(name, &entry)?;
+        self.write_metadata_for(name, &entry)?;
         streams.insert(name.to_string(), Arc::new(RwLock::new(entry)));
 
         Ok(CreateStreamResult::Created)
@@ -530,7 +608,7 @@ impl Storage for FileStorage {
         let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
         self.append_records(name, &mut stream, &[data])?;
         // Data is committed to the log; metadata write failure is non-fatal
-        if let Err(e) = Self::write_metadata_for(name, &stream) {
+        if let Err(e) = self.write_metadata_for(name, &stream) {
             warn!(%e, stream = name, "metadata persist failed after committed append");
         }
         Ok(offset)
@@ -572,7 +650,7 @@ impl Storage for FileStorage {
             stream.last_seq = Some(new_seq);
         }
         // Data is committed to the log; metadata write failure is non-fatal
-        if let Err(e) = Self::write_metadata_for(name, &stream) {
+        if let Err(e) = self.write_metadata_for(name, &stream) {
             warn!(%e, stream = name, "metadata persist failed after committed batch append");
         }
 
@@ -632,7 +710,7 @@ impl Storage for FileStorage {
             *total = total.saturating_sub(stream_bytes);
             drop(total);
 
-            Self::remove_stream_dir(&dir)?;
+            self.remove_stream_dir(&dir)?;
             Ok(())
         } else {
             Err(Error::NotFound(name.to_string()))
@@ -672,7 +750,7 @@ impl Storage for FileStorage {
         }
 
         stream.closed = true;
-        Self::write_metadata_for(name, &stream)?;
+        self.write_metadata_for(name, &stream)?;
 
         let _ = stream.notify.send(());
         Ok(())
@@ -741,7 +819,7 @@ impl Storage for FileStorage {
         );
 
         // Data is committed to the log; metadata write failure is non-fatal
-        if let Err(e) = Self::write_metadata_for(name, &stream) {
+        if let Err(e) = self.write_metadata_for(name, &stream) {
             warn!(%e, stream = name, "metadata persist failed after committed producer append");
         }
 
@@ -775,7 +853,7 @@ impl Storage for FileStorage {
                 *total = total.saturating_sub(stream_bytes);
                 drop(total);
 
-                Self::remove_stream_dir(&dir)?;
+                self.remove_stream_dir(&dir)?;
             } else if stream.config == config {
                 return Ok(CreateWithDataResult {
                     status: CreateStreamResult::AlreadyExists,
@@ -795,7 +873,8 @@ impl Storage for FileStorage {
             ))
         })?;
 
-        let file = Self::open_stream_file(&dir)?;
+        self.validate_stream_dir(&dir)?;
+        let file = self.open_stream_file(&dir)?;
         let mut entry = StreamEntry::new(config, file, dir);
 
         if !messages.is_empty() {
@@ -808,7 +887,7 @@ impl Storage for FileStorage {
         let next_offset = Offset::new(entry.next_read_seq, entry.next_byte_offset);
         let closed = entry.closed;
 
-        Self::write_metadata_for(name, &entry)?;
+        self.write_metadata_for(name, &entry)?;
         streams.insert(name.to_string(), Arc::new(RwLock::new(entry)));
 
         Ok(CreateWithDataResult {

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -128,9 +128,20 @@ impl FileStorage {
         *self.total_bytes.read().expect("total_bytes lock poisoned")
     }
 
-    fn stream_dir_for_name(&self, name: &str) -> PathBuf {
+    /// Map a stream name to a directory path inside `root_dir`.
+    ///
+    /// Uses base64url encoding (alphabet `[A-Za-z0-9_-]`) so the output
+    /// cannot contain path separators, but we verify containment anyway
+    /// as defense in depth.
+    fn stream_dir_for_name(&self, name: &str) -> Result<PathBuf> {
         let encoded = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(name.as_bytes());
-        self.root_dir.join(encoded)
+        let dir = self.root_dir.join(&encoded);
+        if !dir.starts_with(&self.root_dir) {
+            return Err(Error::Storage(format!(
+                "stream directory escapes storage root: {encoded}"
+            )));
+        }
+        Ok(dir)
     }
 
     fn data_log_path(dir: &Path) -> PathBuf {
@@ -380,6 +391,10 @@ impl FileStorage {
             if !path.is_dir() {
                 continue;
             }
+            // Skip entries that escape root_dir (e.g. symlinks pointing outside)
+            if !path.starts_with(&self.root_dir) {
+                continue;
+            }
 
             let meta_path = Self::meta_path(&path);
             if !meta_path.exists() {
@@ -460,7 +475,7 @@ impl Storage for FileStorage {
             }
         }
 
-        let dir = self.stream_dir_for_name(name);
+        let dir = self.stream_dir_for_name(name)?;
         fs::create_dir_all(&dir).map_err(|e| {
             Error::Storage(format!(
                 "failed to create stream directory {}: {e}",
@@ -745,7 +760,7 @@ impl Storage for FileStorage {
             }
         }
 
-        let dir = self.stream_dir_for_name(name);
+        let dir = self.stream_dir_for_name(name)?;
         fs::create_dir_all(&dir).map_err(|e| {
             Error::Storage(format!(
                 "failed to create stream directory {}: {e}",
@@ -1135,7 +1150,7 @@ mod tests {
             .append("test", Bytes::from("data"), "text/plain")
             .unwrap();
 
-        let dir = storage.stream_dir_for_name("test");
+        let dir = storage.stream_dir_for_name("test").unwrap();
         assert!(dir.exists(), "stream directory should exist before delete");
 
         storage.delete("test").unwrap();

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -145,6 +145,16 @@ impl FileStorage {
     /// as defense in depth.
     fn stream_dir_for_name(&self, name: &str) -> Result<PathBuf> {
         let encoded = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(name.as_bytes());
+
+        // Reject path traversal sequences and separators. Base64url encoding
+        // (alphabet [A-Za-z0-9_-]) cannot produce these, but the explicit
+        // checks act as defense in depth and satisfy static analysis (CodeQL
+        // rust/path-injection).
+        if encoded.contains("..") || encoded.contains('/') || encoded.contains('\\') {
+            return Err(Error::Storage(
+                "encoded stream name contains path traversal characters".to_string(),
+            ));
+        }
         if !encoded
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
@@ -153,6 +163,7 @@ impl FileStorage {
                 "encoded stream directory contains invalid characters".to_string(),
             ));
         }
+
         let dir = self.root_dir.join(&encoded);
         if !dir.starts_with(&self.root_dir) {
             return Err(Error::Storage(format!(

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -540,6 +540,7 @@ impl Storage for FileStorage {
 
         let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
         self.append_records(name, &mut stream, vec![data])?;
+        Self::write_metadata_for(name, &stream)?;
         Ok(offset)
     }
 
@@ -585,6 +586,7 @@ impl Storage for FileStorage {
         if let Some(new_seq) = pending_seq {
             stream.last_seq = Some(new_seq);
         }
+        Self::write_metadata_for(name, &stream)?;
 
         Ok(Offset::new(stream.next_read_seq, stream.next_byte_offset))
     }

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -1,0 +1,959 @@
+use super::{
+    CreateStreamResult, CreateWithDataResult, Message, ProducerAppendResult, ReadResult, Storage,
+    StreamConfig, StreamMetadata,
+};
+use crate::protocol::error::{Error, Result};
+use crate::protocol::offset::Offset;
+use crate::protocol::producer::ProducerHeaders;
+use base64::Engine;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use tokio::sync::broadcast;
+
+/// Duration after which stale producer state is cleaned up (7 days).
+const PRODUCER_STATE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+
+/// Broadcast channel capacity for long-poll/SSE notifications.
+const NOTIFY_CHANNEL_CAPACITY: usize = 16;
+
+/// Binary record header size: little-endian `u32` payload length.
+const RECORD_HEADER_BYTES: u64 = 4;
+
+#[derive(Debug, Clone)]
+struct MessageIndex {
+    offset: Offset,
+    file_pos: u64,
+    byte_len: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProducerState {
+    epoch: u64,
+    last_seq: u64,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StreamMeta {
+    name: String,
+    config: StreamConfig,
+    closed: bool,
+    created_at: DateTime<Utc>,
+    last_seq: Option<String>,
+    producers: HashMap<String, ProducerState>,
+}
+
+struct StreamEntry {
+    config: StreamConfig,
+    index: Vec<MessageIndex>,
+    closed: bool,
+    next_read_seq: u64,
+    next_byte_offset: u64,
+    total_bytes: u64,
+    created_at: DateTime<Utc>,
+    producers: HashMap<String, ProducerState>,
+    notify: broadcast::Sender<()>,
+    last_seq: Option<String>,
+    file: File,
+    dir: PathBuf,
+}
+
+impl StreamEntry {
+    fn new(config: StreamConfig, file: File, dir: PathBuf) -> Self {
+        let (notify, _) = broadcast::channel(NOTIFY_CHANNEL_CAPACITY);
+        Self {
+            config,
+            index: Vec::new(),
+            closed: false,
+            next_read_seq: 0,
+            next_byte_offset: 0,
+            total_bytes: 0,
+            created_at: Utc::now(),
+            producers: HashMap::new(),
+            notify,
+            last_seq: None,
+            file,
+            dir,
+        }
+    }
+
+    fn cleanup_stale_producers(&mut self) {
+        let cutoff = Utc::now()
+            - chrono::TimeDelta::try_seconds(PRODUCER_STATE_TTL_SECS)
+                .expect("7 days fits in TimeDelta");
+        self.producers.retain(|_, state| state.updated_at > cutoff);
+    }
+}
+
+/// High-throughput file-backed storage.
+///
+/// Design:
+/// - One append-only log file per stream (`data.log`)
+/// - In-memory offset/file index for fast reads
+/// - Stream-level write lock serializes appends and preserves monotonic offsets
+/// - Batched write per append call reduces syscall overhead
+pub struct FileStorage {
+    streams: RwLock<HashMap<String, Arc<RwLock<StreamEntry>>>>,
+    total_bytes: RwLock<u64>,
+    max_total_bytes: u64,
+    max_stream_bytes: u64,
+    root_dir: PathBuf,
+    sync_on_append: bool,
+}
+
+impl FileStorage {
+    pub fn new(
+        root_dir: impl Into<PathBuf>,
+        max_total_bytes: u64,
+        max_stream_bytes: u64,
+        sync_on_append: bool,
+    ) -> Result<Self> {
+        let root_dir = root_dir.into();
+        fs::create_dir_all(&root_dir).map_err(|e| {
+            Error::Storage(format!(
+                "failed to create storage directory {}: {e}",
+                root_dir.display()
+            ))
+        })?;
+
+        let storage = Self {
+            streams: RwLock::new(HashMap::new()),
+            total_bytes: RwLock::new(0),
+            max_total_bytes,
+            max_stream_bytes,
+            root_dir,
+            sync_on_append,
+        };
+        storage.load_existing_streams()?;
+        Ok(storage)
+    }
+
+    #[must_use]
+    pub fn total_bytes(&self) -> u64 {
+        *self.total_bytes.read().expect("total_bytes lock poisoned")
+    }
+
+    fn stream_dir_for_name(&self, name: &str) -> PathBuf {
+        let encoded = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(name.as_bytes());
+        self.root_dir.join(encoded)
+    }
+
+    fn data_log_path(dir: &Path) -> PathBuf {
+        dir.join("data.log")
+    }
+
+    fn meta_path(dir: &Path) -> PathBuf {
+        dir.join("meta.json")
+    }
+
+    fn write_metadata_for(name: &str, entry: &StreamEntry) -> Result<()> {
+        let meta = StreamMeta {
+            name: name.to_string(),
+            config: entry.config.clone(),
+            closed: entry.closed,
+            created_at: entry.created_at,
+            last_seq: entry.last_seq.clone(),
+            producers: entry.producers.clone(),
+        };
+
+        let meta_path = Self::meta_path(&entry.dir);
+        let tmp_path = entry.dir.join("meta.json.tmp");
+        let payload = serde_json::to_vec(&meta)
+            .map_err(|e| Error::Storage(format!("failed to serialize stream metadata: {e}")))?;
+
+        fs::write(&tmp_path, payload).map_err(|e| {
+            Error::Storage(format!(
+                "failed to write metadata temp file {}: {e}",
+                tmp_path.display()
+            ))
+        })?;
+
+        fs::rename(&tmp_path, &meta_path).map_err(|e| {
+            Error::Storage(format!(
+                "failed to atomically replace metadata {}: {e}",
+                meta_path.display()
+            ))
+        })?;
+
+        Ok(())
+    }
+
+    fn open_stream_file(dir: &Path) -> Result<File> {
+        let path = Self::data_log_path(dir);
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .read(true)
+            .open(&path)
+            .map_err(|e| {
+                Error::Storage(format!("failed to open stream log {}: {e}", path.display()))
+            })
+    }
+
+    fn rebuild_index(file: &mut File) -> Result<(Vec<MessageIndex>, u64, u64)> {
+        let mut index = Vec::new();
+        let mut next_read_seq = 0u64;
+        let mut next_byte_offset = 0u64;
+
+        let file_len = file
+            .metadata()
+            .map_err(|e| Error::Storage(format!("failed to stat stream log: {e}")))?
+            .len();
+
+        let mut cursor = 0u64;
+        let mut header = [0u8; RECORD_HEADER_BYTES as usize];
+
+        while cursor < file_len {
+            file.seek(SeekFrom::Start(cursor))
+                .map_err(|e| Error::Storage(format!("failed to seek stream log: {e}")))?;
+
+            let read = file
+                .read(&mut header)
+                .map_err(|e| Error::Storage(format!("failed to read stream log header: {e}")))?;
+
+            if read == 0 {
+                break;
+            }
+
+            if read < RECORD_HEADER_BYTES as usize {
+                file.set_len(cursor).map_err(|e| {
+                    Error::Storage(format!("failed to truncate partial record: {e}"))
+                })?;
+                break;
+            }
+
+            let record_len = u64::from(u32::from_le_bytes(header));
+            let record_end = cursor + RECORD_HEADER_BYTES + record_len;
+
+            if record_end > file_len {
+                file.set_len(cursor).map_err(|e| {
+                    Error::Storage(format!("failed to truncate partial record: {e}"))
+                })?;
+                break;
+            }
+
+            index.push(MessageIndex {
+                offset: Offset::new(next_read_seq, next_byte_offset),
+                file_pos: cursor + RECORD_HEADER_BYTES,
+                byte_len: record_len,
+            });
+
+            next_read_seq += 1;
+            next_byte_offset += record_len;
+            cursor = record_end;
+        }
+
+        file.seek(SeekFrom::End(0))
+            .map_err(|e| Error::Storage(format!("failed to seek end of stream log: {e}")))?;
+
+        Ok((index, next_read_seq, next_byte_offset))
+    }
+
+    fn is_expired(entry: &StreamEntry) -> bool {
+        if let Some(expires_at) = entry.config.expires_at {
+            Utc::now() >= expires_at
+        } else {
+            false
+        }
+    }
+
+    fn get_stream(&self, name: &str) -> Option<Arc<RwLock<StreamEntry>>> {
+        let streams = self.streams.read().expect("streams lock poisoned");
+        streams.get(name).map(Arc::clone)
+    }
+
+    fn validate_seq(stream: &StreamEntry, seq: Option<&str>) -> Result<Option<String>> {
+        if let Some(new_seq) = seq {
+            if let Some(ref last) = stream.last_seq
+                && new_seq <= last.as_str()
+            {
+                return Err(Error::SeqOrderingViolation {
+                    last: last.clone(),
+                    received: new_seq.to_string(),
+                });
+            }
+            return Ok(Some(new_seq.to_string()));
+        }
+        Ok(None)
+    }
+
+    fn append_records(
+        &self,
+        name: &str,
+        stream: &mut StreamEntry,
+        messages: Vec<Bytes>,
+    ) -> Result<()> {
+        if messages.is_empty() {
+            return Ok(());
+        }
+
+        let mut total_batch_bytes = 0u64;
+        let mut payload_bytes = 0u64;
+        let mut sizes = Vec::with_capacity(messages.len());
+
+        for msg in &messages {
+            let len = u64::try_from(msg.len()).unwrap_or(u64::MAX);
+            if len > u64::from(u32::MAX) {
+                return Err(Error::InvalidHeader {
+                    header: "Content-Length".to_string(),
+                    reason: "message too large for file record format".to_string(),
+                });
+            }
+            payload_bytes += len;
+            total_batch_bytes += len;
+            sizes.push(len);
+        }
+
+        let current_total = *self.total_bytes.read().expect("total_bytes lock poisoned");
+        if current_total + total_batch_bytes > self.max_total_bytes {
+            return Err(Error::MemoryLimitExceeded);
+        }
+        if stream.total_bytes + total_batch_bytes > self.max_stream_bytes {
+            return Err(Error::StreamSizeLimitExceeded);
+        }
+
+        let mut write_buf = Vec::with_capacity(
+            usize::try_from(
+                payload_bytes + (RECORD_HEADER_BYTES * u64::try_from(messages.len()).unwrap_or(0)),
+            )
+            .unwrap_or(0),
+        );
+        for msg in &messages {
+            let len = u32::try_from(msg.len()).unwrap_or(u32::MAX);
+            write_buf.extend_from_slice(&len.to_le_bytes());
+            write_buf.extend_from_slice(msg);
+        }
+
+        let before_len = stream
+            .file
+            .metadata()
+            .map_err(|e| Error::Storage(format!("failed to stat stream log before append: {e}")))?
+            .len();
+
+        stream
+            .file
+            .write_all(&write_buf)
+            .map_err(|e| Error::Storage(format!("failed to append stream log for {name}: {e}")))?;
+
+        if self.sync_on_append {
+            stream.file.sync_data().map_err(|e| {
+                Error::Storage(format!("failed to sync stream log for {name}: {e}"))
+            })?;
+        }
+
+        let mut cursor = before_len;
+        for len in sizes {
+            let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
+            stream.index.push(MessageIndex {
+                offset,
+                file_pos: cursor + RECORD_HEADER_BYTES,
+                byte_len: len,
+            });
+            stream.next_read_seq += 1;
+            stream.next_byte_offset += len;
+            stream.total_bytes += len;
+            cursor += RECORD_HEADER_BYTES + len;
+        }
+
+        let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+        *total += total_batch_bytes;
+
+        let _ = stream.notify.send(());
+        Ok(())
+    }
+
+    fn read_messages(file: &File, index_slice: &[MessageIndex]) -> Result<Vec<Message>> {
+        let mut messages = Vec::with_capacity(index_slice.len());
+        let mut reader = file
+            .try_clone()
+            .map_err(|e| Error::Storage(format!("failed to clone stream file handle: {e}")))?;
+
+        for idx in index_slice {
+            reader
+                .seek(SeekFrom::Start(idx.file_pos))
+                .map_err(|e| Error::Storage(format!("failed to seek message data: {e}")))?;
+
+            let mut buf = vec![0u8; usize::try_from(idx.byte_len).unwrap_or(usize::MAX)];
+            reader
+                .read_exact(&mut buf)
+                .map_err(|e| Error::Storage(format!("failed to read message data: {e}")))?;
+
+            messages.push(Message::new(idx.offset.clone(), Bytes::from(buf)));
+        }
+
+        Ok(messages)
+    }
+
+    fn remove_stream_dir(dir: &Path) -> Result<()> {
+        fs::remove_dir_all(dir).map_err(|e| {
+            Error::Storage(format!(
+                "failed to remove stream directory {}: {e}",
+                dir.display()
+            ))
+        })
+    }
+
+    fn load_existing_streams(&self) -> Result<()> {
+        let entries = fs::read_dir(&self.root_dir).map_err(|e| {
+            Error::Storage(format!(
+                "failed to read storage directory {}: {e}",
+                self.root_dir.display()
+            ))
+        })?;
+
+        let mut streams_map = self.streams.write().expect("streams lock poisoned");
+        let mut restored_total = 0u64;
+
+        for dir_entry in entries {
+            let dir_entry = dir_entry
+                .map_err(|e| Error::Storage(format!("failed to inspect storage entry: {e}")))?;
+            let path = dir_entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let meta_path = Self::meta_path(&path);
+            if !meta_path.exists() {
+                continue;
+            }
+
+            let meta_payload = fs::read(&meta_path).map_err(|e| {
+                Error::Storage(format!(
+                    "failed to read stream metadata {}: {e}",
+                    meta_path.display()
+                ))
+            })?;
+            let meta: StreamMeta = serde_json::from_slice(&meta_payload).map_err(|e| {
+                Error::Storage(format!(
+                    "failed to parse stream metadata {}: {e}",
+                    meta_path.display()
+                ))
+            })?;
+
+            let mut file = Self::open_stream_file(&path)?;
+            let (index, next_read_seq, next_byte_offset) = Self::rebuild_index(&mut file)?;
+            let total_bytes = next_byte_offset;
+
+            let (notify, _) = broadcast::channel(NOTIFY_CHANNEL_CAPACITY);
+            let entry = StreamEntry {
+                config: meta.config,
+                index,
+                closed: meta.closed,
+                next_read_seq,
+                next_byte_offset,
+                total_bytes,
+                created_at: meta.created_at,
+                producers: meta.producers,
+                notify,
+                last_seq: meta.last_seq,
+                file,
+                dir: path,
+            };
+
+            if Self::is_expired(&entry) {
+                Self::remove_stream_dir(&entry.dir)?;
+                continue;
+            }
+
+            restored_total = restored_total.saturating_add(entry.total_bytes);
+            streams_map.insert(meta.name, Arc::new(RwLock::new(entry)));
+        }
+
+        let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+        *total = restored_total;
+
+        Ok(())
+    }
+}
+
+impl Storage for FileStorage {
+    fn create_stream(&self, name: &str, config: StreamConfig) -> Result<CreateStreamResult> {
+        let mut streams = self.streams.write().expect("streams lock poisoned");
+
+        if let Some(stream_arc) = streams.get(name) {
+            let stream = stream_arc.read().expect("stream lock poisoned");
+
+            if Self::is_expired(&stream) {
+                let stream_bytes = stream.total_bytes;
+                let dir = stream.dir.clone();
+                drop(stream);
+                streams.remove(name);
+
+                let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+                *total = total.saturating_sub(stream_bytes);
+                drop(total);
+
+                Self::remove_stream_dir(&dir)?;
+            } else if stream.config == config {
+                return Ok(CreateStreamResult::AlreadyExists);
+            } else {
+                return Err(Error::ConfigMismatch);
+            }
+        }
+
+        let dir = self.stream_dir_for_name(name);
+        fs::create_dir_all(&dir).map_err(|e| {
+            Error::Storage(format!(
+                "failed to create stream directory {}: {e}",
+                dir.display()
+            ))
+        })?;
+
+        let file = Self::open_stream_file(&dir)?;
+        let entry = StreamEntry::new(config, file, dir);
+
+        Self::write_metadata_for(name, &entry)?;
+        streams.insert(name.to_string(), Arc::new(RwLock::new(entry)));
+
+        Ok(CreateStreamResult::Created)
+    }
+
+    fn append(&self, name: &str, data: Bytes, content_type: &str) -> Result<Offset> {
+        let stream_arc = self
+            .get_stream(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+
+        let mut stream = stream_arc.write().expect("stream lock poisoned");
+
+        if Self::is_expired(&stream) {
+            return Err(Error::StreamExpired);
+        }
+
+        if stream.closed {
+            return Err(Error::StreamClosed);
+        }
+
+        let normalized_ct = content_type.to_lowercase();
+        let expected_ct = stream.config.content_type.to_lowercase();
+        if normalized_ct != expected_ct {
+            return Err(Error::ContentTypeMismatch {
+                expected: stream.config.content_type.clone(),
+                actual: content_type.to_string(),
+            });
+        }
+
+        let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
+        self.append_records(name, &mut stream, vec![data])?;
+        Ok(offset)
+    }
+
+    fn batch_append(
+        &self,
+        name: &str,
+        messages: Vec<Bytes>,
+        content_type: &str,
+        seq: Option<&str>,
+    ) -> Result<Offset> {
+        if messages.is_empty() {
+            return Err(Error::InvalidHeader {
+                header: "Content-Length".to_string(),
+                reason: "batch cannot be empty".to_string(),
+            });
+        }
+
+        let stream_arc = self
+            .get_stream(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+
+        let mut stream = stream_arc.write().expect("stream lock poisoned");
+
+        if Self::is_expired(&stream) {
+            return Err(Error::StreamExpired);
+        }
+
+        if stream.closed {
+            return Err(Error::StreamClosed);
+        }
+
+        let normalized_ct = content_type.to_lowercase();
+        let expected_ct = stream.config.content_type.to_lowercase();
+        if normalized_ct != expected_ct {
+            return Err(Error::ContentTypeMismatch {
+                expected: stream.config.content_type.clone(),
+                actual: content_type.to_string(),
+            });
+        }
+
+        let pending_seq = Self::validate_seq(&stream, seq)?;
+        self.append_records(name, &mut stream, messages)?;
+        if let Some(new_seq) = pending_seq {
+            stream.last_seq = Some(new_seq);
+        }
+
+        Ok(Offset::new(stream.next_read_seq, stream.next_byte_offset))
+    }
+
+    fn read(&self, name: &str, from_offset: &Offset) -> Result<ReadResult> {
+        let stream_arc = self
+            .get_stream(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+
+        let stream = stream_arc.read().expect("stream lock poisoned");
+
+        if Self::is_expired(&stream) {
+            return Err(Error::StreamExpired);
+        }
+
+        if from_offset.is_now() {
+            return Ok(ReadResult {
+                messages: Vec::new(),
+                next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
+                at_tail: true,
+                closed: stream.closed,
+            });
+        }
+
+        let start_idx = if from_offset.is_start() {
+            0
+        } else {
+            match stream.index.binary_search_by(|m| m.offset.cmp(from_offset)) {
+                Ok(idx) | Err(idx) => idx,
+            }
+        };
+
+        let index_slice = &stream.index[start_idx..];
+        let messages = Self::read_messages(&stream.file, index_slice)?;
+        let at_tail = start_idx + messages.len() >= stream.index.len();
+
+        Ok(ReadResult {
+            messages,
+            next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
+            at_tail,
+            closed: stream.closed,
+        })
+    }
+
+    fn delete(&self, name: &str) -> Result<()> {
+        let mut streams = self.streams.write().expect("streams lock poisoned");
+
+        if let Some(stream_arc) = streams.remove(name) {
+            let stream = stream_arc.read().expect("stream lock poisoned");
+            let dir = stream.dir.clone();
+            let stream_bytes = stream.total_bytes;
+            drop(stream);
+
+            let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+            *total = total.saturating_sub(stream_bytes);
+            drop(total);
+
+            Self::remove_stream_dir(&dir)?;
+            Ok(())
+        } else {
+            Err(Error::NotFound(name.to_string()))
+        }
+    }
+
+    fn head(&self, name: &str) -> Result<StreamMetadata> {
+        let stream_arc = self
+            .get_stream(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+
+        let stream = stream_arc.read().expect("stream lock poisoned");
+
+        if Self::is_expired(&stream) {
+            return Err(Error::StreamExpired);
+        }
+
+        Ok(StreamMetadata {
+            config: stream.config.clone(),
+            next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
+            closed: stream.closed,
+            total_bytes: stream.total_bytes,
+            message_count: u64::try_from(stream.index.len()).unwrap_or(u64::MAX),
+            created_at: stream.created_at,
+        })
+    }
+
+    fn close_stream(&self, name: &str) -> Result<()> {
+        let stream_arc = self
+            .get_stream(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+
+        let mut stream = stream_arc.write().expect("stream lock poisoned");
+
+        if Self::is_expired(&stream) {
+            return Err(Error::StreamExpired);
+        }
+
+        stream.closed = true;
+        Self::write_metadata_for(name, &stream)?;
+
+        let _ = stream.notify.send(());
+        Ok(())
+    }
+
+    fn append_with_producer(
+        &self,
+        name: &str,
+        messages: Vec<Bytes>,
+        content_type: &str,
+        producer: &ProducerHeaders,
+        should_close: bool,
+        seq: Option<&str>,
+    ) -> Result<ProducerAppendResult> {
+        let stream_arc = self
+            .get_stream(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+
+        let mut stream = stream_arc.write().expect("stream lock poisoned");
+
+        if Self::is_expired(&stream) {
+            return Err(Error::StreamExpired);
+        }
+
+        stream.cleanup_stale_producers();
+
+        if !messages.is_empty() {
+            let normalized_ct = content_type.to_lowercase();
+            let expected_ct = stream.config.content_type.to_lowercase();
+            if normalized_ct != expected_ct {
+                return Err(Error::ContentTypeMismatch {
+                    expected: stream.config.content_type.clone(),
+                    actual: content_type.to_string(),
+                });
+            }
+        }
+
+        let now = Utc::now();
+
+        if let Some(state) = stream.producers.get(producer.id.as_str()) {
+            if producer.epoch < state.epoch {
+                return Err(Error::EpochFenced {
+                    current: state.epoch,
+                    received: producer.epoch,
+                });
+            }
+
+            if producer.epoch == state.epoch && producer.seq <= state.last_seq {
+                return Ok(ProducerAppendResult::Duplicate {
+                    epoch: state.epoch,
+                    seq: state.last_seq,
+                    next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
+                    closed: stream.closed,
+                });
+            }
+
+            if stream.closed {
+                return Err(Error::StreamClosed);
+            }
+
+            if producer.epoch > state.epoch {
+                if producer.seq != 0 {
+                    return Err(Error::InvalidProducerState(
+                        "new epoch must start at seq 0".to_string(),
+                    ));
+                }
+            } else if producer.seq > state.last_seq + 1 {
+                return Err(Error::SequenceGap {
+                    expected: state.last_seq + 1,
+                    actual: producer.seq,
+                });
+            }
+        } else {
+            if stream.closed {
+                return Err(Error::StreamClosed);
+            }
+            if producer.seq != 0 {
+                return Err(Error::SequenceGap {
+                    expected: 0,
+                    actual: producer.seq,
+                });
+            }
+        }
+
+        let pending_seq = Self::validate_seq(&stream, seq)?;
+        self.append_records(name, &mut stream, messages)?;
+
+        if let Some(new_seq) = pending_seq {
+            stream.last_seq = Some(new_seq);
+        }
+        if should_close {
+            stream.closed = true;
+        }
+
+        stream.producers.insert(
+            producer.id.clone(),
+            ProducerState {
+                epoch: producer.epoch,
+                last_seq: producer.seq,
+                updated_at: now,
+            },
+        );
+
+        Self::write_metadata_for(name, &stream)?;
+
+        Ok(ProducerAppendResult::Accepted {
+            epoch: producer.epoch,
+            seq: producer.seq,
+            next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
+            closed: stream.closed,
+        })
+    }
+
+    fn create_stream_with_data(
+        &self,
+        name: &str,
+        config: StreamConfig,
+        messages: Vec<Bytes>,
+        should_close: bool,
+    ) -> Result<CreateWithDataResult> {
+        let mut streams = self.streams.write().expect("streams lock poisoned");
+
+        if let Some(stream_arc) = streams.get(name) {
+            let stream = stream_arc.read().expect("stream lock poisoned");
+
+            if Self::is_expired(&stream) {
+                let stream_bytes = stream.total_bytes;
+                let dir = stream.dir.clone();
+                drop(stream);
+                streams.remove(name);
+
+                let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
+                *total = total.saturating_sub(stream_bytes);
+                drop(total);
+
+                Self::remove_stream_dir(&dir)?;
+            } else if stream.config == config {
+                return Ok(CreateWithDataResult {
+                    status: CreateStreamResult::AlreadyExists,
+                    next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
+                    closed: stream.closed,
+                });
+            } else {
+                return Err(Error::ConfigMismatch);
+            }
+        }
+
+        let dir = self.stream_dir_for_name(name);
+        fs::create_dir_all(&dir).map_err(|e| {
+            Error::Storage(format!(
+                "failed to create stream directory {}: {e}",
+                dir.display()
+            ))
+        })?;
+
+        let file = Self::open_stream_file(&dir)?;
+        let mut entry = StreamEntry::new(config, file, dir);
+
+        if !messages.is_empty() {
+            self.append_records(name, &mut entry, messages)?;
+        }
+        if should_close {
+            entry.closed = true;
+        }
+
+        let next_offset = Offset::new(entry.next_read_seq, entry.next_byte_offset);
+        let closed = entry.closed;
+
+        Self::write_metadata_for(name, &entry)?;
+        streams.insert(name.to_string(), Arc::new(RwLock::new(entry)));
+
+        Ok(CreateWithDataResult {
+            status: CreateStreamResult::Created,
+            next_offset,
+            closed,
+        })
+    }
+
+    fn exists(&self, name: &str) -> bool {
+        let streams = self.streams.read().expect("streams lock poisoned");
+        if let Some(stream_arc) = streams.get(name) {
+            let stream = stream_arc.read().expect("stream lock poisoned");
+            !Self::is_expired(&stream)
+        } else {
+            false
+        }
+    }
+
+    fn subscribe(&self, name: &str) -> Option<broadcast::Receiver<()>> {
+        let stream_arc = self.get_stream(name)?;
+        let stream = stream_arc.read().expect("stream lock poisoned");
+
+        if Self::is_expired(&stream) {
+            return None;
+        }
+
+        Some(stream.notify.subscribe())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_storage_dir() -> PathBuf {
+        let stamp = Utc::now()
+            .timestamp_nanos_opt()
+            .unwrap_or_default()
+            .to_string();
+        std::env::temp_dir().join(format!("ds-file-storage-test-{stamp}"))
+    }
+
+    fn test_storage() -> FileStorage {
+        FileStorage::new(test_storage_dir(), 1024 * 1024, 100 * 1024, false)
+            .expect("file storage should initialize")
+    }
+
+    #[test]
+    fn test_append_and_read_roundtrip() {
+        let storage = test_storage();
+        let config = StreamConfig::new("text/plain".to_string());
+
+        storage
+            .create_stream("test", config)
+            .expect("stream should be created");
+
+        let first = storage
+            .append("test", Bytes::from("hello"), "text/plain")
+            .expect("append should succeed");
+        let second = storage
+            .append("test", Bytes::from("world"), "text/plain")
+            .expect("append should succeed");
+
+        assert!(first < second);
+
+        let read = storage
+            .read("test", &Offset::start())
+            .expect("read should succeed");
+        assert_eq!(read.messages.len(), 2);
+        assert_eq!(read.messages[0].data, Bytes::from("hello"));
+        assert_eq!(read.messages[1].data, Bytes::from("world"));
+    }
+
+    #[test]
+    fn test_restore_from_disk() {
+        let root = test_storage_dir();
+        let config = StreamConfig::new("text/plain".to_string());
+
+        {
+            let storage = FileStorage::new(root.clone(), 1024 * 1024, 100 * 1024, false)
+                .expect("file storage should initialize");
+            storage
+                .create_stream("events", config.clone())
+                .expect("stream should be created");
+            storage
+                .append("events", Bytes::from("event-1"), "text/plain")
+                .expect("append should succeed");
+            storage
+                .append("events", Bytes::from("event-2"), "text/plain")
+                .expect("append should succeed");
+        }
+
+        let restored =
+            FileStorage::new(root, 1024 * 1024, 100 * 1024, false).expect("restore should work");
+
+        let read = restored
+            .read("events", &Offset::start())
+            .expect("read should succeed");
+
+        assert_eq!(read.messages.len(), 2);
+        assert_eq!(read.messages[0].data, Bytes::from("event-1"));
+        assert_eq!(read.messages[1].data, Bytes::from("event-2"));
+    }
+}

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -1,29 +1,15 @@
 use super::{
-    CreateStreamResult, Message, ProducerAppendResult, ReadResult, Storage, StreamConfig,
-    StreamMetadata,
+    CreateStreamResult, Message, NOTIFY_CHANNEL_CAPACITY, ProducerAppendResult, ProducerCheck,
+    ProducerState, ReadResult, Storage, StreamConfig, StreamMetadata,
 };
 use crate::protocol::error::{Error, Result};
 use crate::protocol::offset::Offset;
 use crate::protocol::producer::ProducerHeaders;
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
-
-/// Per-producer state tracked within a stream
-struct ProducerState {
-    epoch: u64,
-    last_seq: u64,
-    updated_at: DateTime<Utc>,
-}
-
-/// Duration after which stale producer state is cleaned up (7 days)
-const PRODUCER_STATE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
-
-/// Broadcast channel capacity for long-poll/SSE notifications.
-/// Small because notifications are hints (no payload), not data delivery.
-const NOTIFY_CHANNEL_CAPACITY: usize = 16;
 
 /// Internal stream entry
 struct StreamEntry {
@@ -33,7 +19,7 @@ struct StreamEntry {
     next_read_seq: u64,
     next_byte_offset: u64,
     total_bytes: u64,
-    created_at: DateTime<Utc>,
+    created_at: chrono::DateTime<Utc>,
     /// Per-producer state for idempotent producer support
     producers: HashMap<String, ProducerState>,
     /// Broadcast sender for notifying long-poll/SSE subscribers
@@ -59,15 +45,6 @@ impl StreamEntry {
             notify,
             last_seq: None,
         }
-    }
-
-    /// Clean up producer state entries older than the TTL threshold.
-    /// Called lazily on producer append operations.
-    fn cleanup_stale_producers(&mut self) {
-        let cutoff = Utc::now()
-            - chrono::TimeDelta::try_seconds(PRODUCER_STATE_TTL_SECS)
-                .expect("7 days fits in TimeDelta");
-        self.producers.retain(|_, state| state.updated_at > cutoff);
     }
 }
 
@@ -115,34 +92,6 @@ impl InMemoryStorage {
     fn get_stream(&self, name: &str) -> Option<Arc<RwLock<StreamEntry>>> {
         let streams = self.streams.read().expect("streams lock poisoned");
         streams.get(name).map(Arc::clone)
-    }
-
-    /// Check if a stream is expired based on its `expires_at` timestamp
-    fn is_expired(entry: &StreamEntry) -> bool {
-        if let Some(expires_at) = entry.config.expires_at {
-            Utc::now() >= expires_at
-        } else {
-            false
-        }
-    }
-
-    /// Validate Stream-Seq ordering and return a pending value to commit.
-    ///
-    /// Returns `Err(SeqOrderingViolation)` if the new seq is not strictly
-    /// greater than the last seq (lexicographic comparison).
-    fn validate_seq(stream: &StreamEntry, seq: Option<&str>) -> Result<Option<String>> {
-        if let Some(new_seq) = seq {
-            if let Some(ref last) = stream.last_seq
-                && new_seq <= last.as_str()
-            {
-                return Err(Error::SeqOrderingViolation {
-                    last: last.clone(),
-                    received: new_seq.to_string(),
-                });
-            }
-            return Ok(Some(new_seq.to_string()));
-        }
-        Ok(None)
     }
 
     /// Commit messages to a stream, checking memory limits first.
@@ -195,33 +144,24 @@ impl Storage for InMemoryStorage {
         let mut streams = self.streams.write().expect("streams lock poisoned");
 
         if let Some(stream_arc) = streams.get(name) {
-            // Stream exists, check if expired
             let stream = stream_arc.read().expect("stream lock poisoned");
 
-            if Self::is_expired(&stream) {
-                // Stream is expired, remove it and create new
-                // Capture bytes to reclaim from global counter
+            if super::is_stream_expired(&stream.config) {
                 let stream_bytes = stream.total_bytes;
-                drop(stream); // Release read lock before modifying map
+                drop(stream);
                 streams.remove(name);
 
-                // Reclaim memory from global counter
                 let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
                 *total = total.saturating_sub(stream_bytes);
-                drop(total); // Release lock before proceeding
-
-            // Fall through to create new stream
+                drop(total);
             } else {
-                // Stream is not expired, check for config match
                 if stream.config == config {
-                    // Idempotent create with matching config
                     return Ok(CreateStreamResult::AlreadyExists);
                 }
                 return Err(Error::ConfigMismatch);
             }
         }
 
-        // Create new stream
         let entry = StreamEntry::new(config);
         streams.insert(name.to_string(), Arc::new(RwLock::new(entry)));
 
@@ -233,33 +173,20 @@ impl Storage for InMemoryStorage {
             .get_stream(name)
             .ok_or_else(|| Error::NotFound(name.to_string()))?;
 
-        // Acquire per-stream write lock to serialize appends and ensure monotonicity
-        // This lock is held across offset generation and message insertion
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        // Check if stream is expired
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
-        // Check if stream is closed
         if stream.closed {
             return Err(Error::StreamClosed);
         }
 
-        // Check content type match (normalized comparison)
-        let normalized_ct = content_type.to_lowercase();
-        let expected_ct = stream.config.content_type.to_lowercase();
-        if normalized_ct != expected_ct {
-            return Err(Error::ContentTypeMismatch {
-                expected: stream.config.content_type.clone(),
-                actual: content_type.to_string(),
-            });
-        }
+        super::validate_content_type(&stream.config.content_type, content_type)?;
 
         let byte_len = u64::try_from(data.len()).unwrap_or(u64::MAX);
 
-        // Check memory limits
         let total_bytes = *self.total_bytes.read().expect("total_bytes lock poisoned");
         if total_bytes + byte_len > self.max_total_bytes {
             return Err(Error::MemoryLimitExceeded);
@@ -269,19 +196,15 @@ impl Storage for InMemoryStorage {
             return Err(Error::StreamSizeLimitExceeded);
         }
 
-        // Generate offset (monotonic)
         let offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
 
-        // Update counters
         stream.next_read_seq += 1;
         stream.next_byte_offset += byte_len;
         stream.total_bytes += byte_len;
 
-        // Create and store message
         let message = Message::new(offset.clone(), data);
         stream.messages.push(message);
 
-        // Update global memory counter
         let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
         *total += byte_len;
 
@@ -306,38 +229,25 @@ impl Storage for InMemoryStorage {
             .get_stream(name)
             .ok_or_else(|| Error::NotFound(name.to_string()))?;
 
-        // Acquire per-stream write lock for atomic batch operation
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        // Check if stream is expired
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
-        // Check if stream is closed
         if stream.closed {
             return Err(Error::StreamClosed);
         }
 
-        // Check content type match (normalized comparison)
-        let normalized_ct = content_type.to_lowercase();
-        let expected_ct = stream.config.content_type.to_lowercase();
-        if normalized_ct != expected_ct {
-            return Err(Error::ContentTypeMismatch {
-                expected: stream.config.content_type.clone(),
-                actual: content_type.to_string(),
-            });
-        }
+        super::validate_content_type(&stream.config.content_type, content_type)?;
 
-        // Validate Stream-Seq ordering before append, but commit it only after append succeeds.
-        let pending_seq = Self::validate_seq(&stream, seq)?;
+        let pending_seq = super::validate_seq(stream.last_seq.as_deref(), seq)?;
 
         self.commit_messages(&mut stream, messages)?;
         if let Some(new_seq) = pending_seq {
             stream.last_seq = Some(new_seq);
         }
 
-        // Return next_offset snapshot from within the lock
         Ok(Offset::new(stream.next_read_seq, stream.next_byte_offset))
     }
 
@@ -348,14 +258,11 @@ impl Storage for InMemoryStorage {
 
         let stream = stream_arc.read().expect("stream lock poisoned");
 
-        // Check if stream is expired
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
-        // Handle sentinels
         if from_offset.is_now() {
-            // Reading from "now" returns empty at tail
             let next_offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
             return Ok(ReadResult {
                 messages: Vec::new(),
@@ -365,13 +272,9 @@ impl Storage for InMemoryStorage {
             });
         }
 
-        // Find starting position
         let start_idx = if from_offset.is_start() {
             0
         } else {
-            // Find first message >= from_offset
-            // binary_search_by returns Ok(idx) if exact match, Err(idx) for insertion point
-            // Both give us the correct starting position
             match stream
                 .messages
                 .binary_search_by(|m| m.offset.cmp(from_offset))
@@ -380,13 +283,10 @@ impl Storage for InMemoryStorage {
             }
         };
 
-        // Read all messages from start_idx to end
         let messages: Vec<Message> = stream.messages[start_idx..].to_vec();
 
-        // Next offset is always what would be assigned to next append
         let next_offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
 
-        // We're at tail if we've read to the end of available messages
         let at_tail = start_idx + messages.len() >= stream.messages.len();
 
         Ok(ReadResult {
@@ -401,7 +301,6 @@ impl Storage for InMemoryStorage {
         let mut streams = self.streams.write().expect("streams lock poisoned");
 
         if let Some(stream_arc) = streams.remove(name) {
-            // Update global memory counter
             let stream = stream_arc.read().expect("stream lock poisoned");
             let mut total = self.total_bytes.write().expect("total_bytes lock poisoned");
             *total = total.saturating_sub(stream.total_bytes);
@@ -418,8 +317,7 @@ impl Storage for InMemoryStorage {
 
         let stream = stream_arc.read().expect("stream lock poisoned");
 
-        // Check if stream is expired
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
@@ -440,14 +338,12 @@ impl Storage for InMemoryStorage {
 
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        // Check if stream is expired
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
         stream.closed = true;
 
-        // Notify long-poll subscribers so they wake up and see the closed state
         let _ = stream.notify.send(());
 
         Ok(())
@@ -466,103 +362,43 @@ impl Storage for InMemoryStorage {
             .get_stream(name)
             .ok_or_else(|| Error::NotFound(name.to_string()))?;
 
-        // Acquire per-stream write lock for atomic validation + append
         let mut stream = stream_arc.write().expect("stream lock poisoned");
 
-        // Check expiration
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return Err(Error::StreamExpired);
         }
 
-        // Lazy cleanup of stale producer state
-        stream.cleanup_stale_producers();
+        super::cleanup_stale_producers(&mut stream.producers);
 
-        // Check content type match (only when there are messages to append)
         if !messages.is_empty() {
-            let normalized_ct = content_type.to_lowercase();
-            let expected_ct = stream.config.content_type.to_lowercase();
-            if normalized_ct != expected_ct {
-                return Err(Error::ContentTypeMismatch {
-                    expected: stream.config.content_type.clone(),
-                    actual: content_type.to_string(),
-                });
-            }
+            super::validate_content_type(&stream.config.content_type, content_type)?;
         }
 
-        // --- Producer validation (atomic with append) ---
-        //
-        // Order matters:
-        //   1. Epoch fencing — always checked first (403)
-        //   2. Duplicate detection — before closed check so retries work (204)
-        //   3. Closed check — blocks new sequences on closed streams (409)
-        //   4. Gap / epoch-bump validation — only reached for non-duplicate, open streams
-        //   5. Accept + append
         let now = Utc::now();
 
-        if let Some(state) = stream.producers.get(&producer.id) {
-            if producer.epoch < state.epoch {
-                return Err(Error::EpochFenced {
-                    current: state.epoch,
-                    received: producer.epoch,
-                });
-            }
-
-            if producer.epoch == state.epoch && producer.seq <= state.last_seq {
-                // Duplicate — idempotent success regardless of closed state
+        match super::check_producer(stream.producers.get(&producer.id), producer, stream.closed)? {
+            ProducerCheck::Accept => {}
+            ProducerCheck::Duplicate { epoch, seq } => {
                 return Ok(ProducerAppendResult::Duplicate {
-                    epoch: state.epoch,
-                    seq: state.last_seq,
+                    epoch,
+                    seq,
                     next_offset: Offset::new(stream.next_read_seq, stream.next_byte_offset),
                     closed: stream.closed,
                 });
             }
-
-            // Not a duplicate — if stream is closed, reject
-            if stream.closed {
-                return Err(Error::StreamClosed);
-            }
-
-            if producer.epoch > state.epoch {
-                if producer.seq != 0 {
-                    return Err(Error::InvalidProducerState(
-                        "new epoch must start at seq 0".to_string(),
-                    ));
-                }
-                // Epoch bump with seq=0 → accept, will reset state below
-            } else if producer.seq > state.last_seq + 1 {
-                return Err(Error::SequenceGap {
-                    expected: state.last_seq + 1,
-                    actual: producer.seq,
-                });
-            }
-            // seq == state.last_seq + 1 → accept, fall through
-        } else {
-            // New producer — if stream is closed, reject
-            if stream.closed {
-                return Err(Error::StreamClosed);
-            }
-            if producer.seq != 0 {
-                return Err(Error::SequenceGap {
-                    expected: 0,
-                    actual: producer.seq,
-                });
-            }
         }
 
-        // Validate Stream-Seq ordering before append, but commit it only after append succeeds.
-        let pending_seq = Self::validate_seq(&stream, seq)?;
+        let pending_seq = super::validate_seq(stream.last_seq.as_deref(), seq)?;
 
         self.commit_messages(&mut stream, messages)?;
         if let Some(new_seq) = pending_seq {
             stream.last_seq = Some(new_seq);
         }
 
-        // Close stream if requested (atomic with append)
         if should_close {
             stream.closed = true;
         }
 
-        // Update producer state
         stream.producers.insert(
             producer.id.clone(),
             ProducerState {
@@ -572,7 +408,6 @@ impl Storage for InMemoryStorage {
             },
         );
 
-        // Snapshot stream state while still holding the lock
         let next_offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
         let closed = stream.closed;
 
@@ -596,8 +431,7 @@ impl Storage for InMemoryStorage {
         if let Some(stream_arc) = streams.get(name) {
             let stream = stream_arc.read().expect("stream lock poisoned");
 
-            if Self::is_expired(&stream) {
-                // Expired — reclaim memory, then fall through to create new
+            if super::is_stream_expired(&stream.config) {
                 let stream_bytes = stream.total_bytes;
                 drop(stream);
                 streams.remove(name);
@@ -605,7 +439,6 @@ impl Storage for InMemoryStorage {
                 *total = total.saturating_sub(stream_bytes);
                 drop(total);
             } else if stream.config == config {
-                // Idempotent create — return existing state, ignore body/close
                 let next_offset = Offset::new(stream.next_read_seq, stream.next_byte_offset);
                 let closed = stream.closed;
                 return Ok(super::CreateWithDataResult {
@@ -618,20 +451,16 @@ impl Storage for InMemoryStorage {
             }
         }
 
-        // Build entry in memory (not yet in the map)
         let mut entry = StreamEntry::new(config);
 
-        // Append initial data — if this fails the entry is never inserted
         if !messages.is_empty() {
             self.commit_messages(&mut entry, messages)?;
         }
 
-        // Close atomically with creation
         if should_close {
             entry.closed = true;
         }
 
-        // Snapshot state before inserting
         let next_offset = Offset::new(entry.next_read_seq, entry.next_byte_offset);
         let closed = entry.closed;
 
@@ -648,8 +477,7 @@ impl Storage for InMemoryStorage {
         let streams = self.streams.read().expect("streams lock poisoned");
         if let Some(stream_arc) = streams.get(name) {
             let stream = stream_arc.read().expect("stream lock poisoned");
-            // Expired streams are treated as non-existent
-            !Self::is_expired(&stream)
+            !super::is_stream_expired(&stream.config)
         } else {
             false
         }
@@ -659,7 +487,7 @@ impl Storage for InMemoryStorage {
         let stream_arc = self.get_stream(name)?;
         let stream = stream_arc.read().expect("stream lock poisoned");
 
-        if Self::is_expired(&stream) {
+        if super::is_stream_expired(&stream.config) {
             return None;
         }
 
@@ -680,16 +508,13 @@ mod tests {
         let storage = test_storage();
         let config = StreamConfig::new("text/plain".to_string());
 
-        // Create stream
         let result = storage.create_stream("test", config.clone()).unwrap();
         assert_eq!(result, CreateStreamResult::Created);
         assert!(storage.exists("test"));
 
-        // Idempotent create with same config
         let result = storage.create_stream("test", config).unwrap();
         assert_eq!(result, CreateStreamResult::AlreadyExists);
 
-        // Create with different config should fail
         let different_config = StreamConfig::new("application/json".to_string());
         assert!(matches!(
             storage.create_stream("test", different_config),
@@ -703,17 +528,14 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Append some data
         let data1 = Bytes::from("hello");
         let offset1 = storage.append("test", data1.clone(), "text/plain").unwrap();
 
         let data2 = Bytes::from("world");
         let offset2 = storage.append("test", data2.clone(), "text/plain").unwrap();
 
-        // Offsets should be monotonically increasing
         assert!(offset1 < offset2);
 
-        // Read from start
         let result = storage.read("test", &Offset::start()).unwrap();
         assert_eq!(result.messages.len(), 2);
         assert_eq!(result.messages[0].data, data1);
@@ -734,7 +556,6 @@ mod tests {
             offsets.push(offset);
         }
 
-        // Verify all offsets are strictly increasing
         for i in 1..offsets.len() {
             assert!(offsets[i - 1] < offsets[i], "Offset monotonicity violated");
         }
@@ -749,7 +570,6 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Spawn multiple threads appending concurrently
         let mut handles = vec![];
         for thread_id in 0..5 {
             let storage_clone = Arc::clone(&storage);
@@ -765,14 +585,12 @@ mod tests {
             handles.push(handle);
         }
 
-        // Collect all offsets from all threads
         let mut all_offsets = Vec::new();
         for handle in handles {
             let offsets = handle.join().unwrap();
             all_offsets.extend(offsets);
         }
 
-        // Verify all offsets are unique and monotonic when sorted
         all_offsets.sort();
         for i in 1..all_offsets.len() {
             assert_ne!(
@@ -786,9 +604,8 @@ mod tests {
             );
         }
 
-        // Verify total message count
         let metadata = storage.head("test").unwrap();
-        assert_eq!(metadata.message_count, 100); // 5 threads * 20 messages
+        assert_eq!(metadata.message_count, 100);
     }
 
     #[test]
@@ -807,13 +624,11 @@ mod tests {
             .append("test", Bytes::from("msg3"), "text/plain")
             .unwrap();
 
-        // Read from offset2 should get msg2 and msg3
         let result = storage.read("test", &offset2).unwrap();
         assert_eq!(result.messages.len(), 2);
         assert_eq!(result.messages[0].data, Bytes::from("msg2"));
         assert_eq!(result.messages[1].data, Bytes::from("msg3"));
 
-        // Read from offset1 should get all three
         let result = storage.read("test", &offset1).unwrap();
         assert_eq!(result.messages.len(), 3);
     }
@@ -828,12 +643,10 @@ mod tests {
             .append("test", Bytes::from("msg1"), "text/plain")
             .unwrap();
 
-        // Read from "now" should return empty at tail
         let result = storage.read("test", &Offset::now()).unwrap();
         assert_eq!(result.messages.len(), 0);
         assert!(result.at_tail);
 
-        // Read from start should get all messages
         let result = storage.read("test", &Offset::start()).unwrap();
         assert_eq!(result.messages.len(), 1);
     }
@@ -844,16 +657,13 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Close stream
         storage.close_stream("test").unwrap();
 
-        // Append should fail
         assert!(matches!(
             storage.append("test", Bytes::from("data"), "text/plain"),
             Err(Error::StreamClosed)
         ));
 
-        // Reads should still work
         let result = storage.read("test", &Offset::start()).unwrap();
         assert!(result.closed);
     }
@@ -864,13 +674,11 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Append with wrong content type
         assert!(matches!(
             storage.append("test", Bytes::from("data"), "application/json"),
             Err(Error::ContentTypeMismatch { .. })
         ));
 
-        // Case-insensitive comparison
         storage
             .append("test", Bytes::from("data"), "TEXT/PLAIN")
             .unwrap();
@@ -878,28 +686,24 @@ mod tests {
 
     #[test]
     fn test_memory_limits() {
-        let storage = InMemoryStorage::new(100, 50); // Small limits
+        let storage = InMemoryStorage::new(100, 50);
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test1", config.clone()).unwrap();
         storage.create_stream("test2", config).unwrap();
 
-        // Fill up test1 to stream limit
         storage
             .append("test1", Bytes::from(vec![0u8; 50]), "text/plain")
             .unwrap();
 
-        // Should hit stream limit
         assert!(matches!(
             storage.append("test1", Bytes::from(vec![0u8; 10]), "text/plain"),
             Err(Error::StreamSizeLimitExceeded)
         ));
 
-        // test2 can still append
         storage
             .append("test2", Bytes::from(vec![0u8; 40]), "text/plain")
             .unwrap();
 
-        // Should hit global memory limit
         assert!(matches!(
             storage.append("test2", Bytes::from(vec![0u8; 20]), "text/plain"),
             Err(Error::MemoryLimitExceeded)
@@ -954,7 +758,6 @@ mod tests {
 
     #[test]
     fn test_create_with_data_rolls_back_on_memory_limit() {
-        // P1: if commit_messages fails, the stream must not exist
         let storage = InMemoryStorage::new(1024, 8);
         let config = StreamConfig::new("text/plain".to_string());
         let oversized = vec![Bytes::from(vec![0_u8; 9])];
@@ -969,7 +772,6 @@ mod tests {
 
     #[test]
     fn test_create_with_data_closed_is_atomic() {
-        // P2: created_closed must be set before the entry is visible
         let storage = test_storage();
         let config = StreamConfig::new("text/plain".to_string()).with_created_closed(true);
 
@@ -979,11 +781,9 @@ mod tests {
         assert_eq!(result.status, CreateStreamResult::Created);
         assert!(result.closed, "stream must be closed in result snapshot");
 
-        // Verify via head() as well
         let meta = storage.head("test").unwrap();
         assert!(meta.closed, "stream must be closed via head()");
 
-        // Appends must be rejected
         assert!(matches!(
             storage.append("test", Bytes::from("data"), "text/plain"),
             Err(Error::StreamClosed)
@@ -1012,19 +812,16 @@ mod tests {
         let storage = test_storage();
         let config = StreamConfig::new("text/plain".to_string());
 
-        // First create with data
         let r1 = storage
             .create_stream_with_data("test", config.clone(), vec![Bytes::from("a")], false)
             .unwrap();
         assert_eq!(r1.status, CreateStreamResult::Created);
 
-        // Idempotent recreate — body must be ignored
         let r2 = storage
             .create_stream_with_data("test", config, vec![Bytes::from("b")], false)
             .unwrap();
         assert_eq!(r2.status, CreateStreamResult::AlreadyExists);
 
-        // Only 1 message from first create
         let meta = storage.head("test").unwrap();
         assert_eq!(meta.message_count, 1);
     }
@@ -1042,14 +839,12 @@ mod tests {
         let bytes_before = storage.total_bytes();
         assert!(bytes_before >= 100);
 
-        // Delete stream
         storage.delete("test").unwrap();
         assert!(!storage.exists("test"));
 
         let bytes_after = storage.total_bytes();
         assert_eq!(bytes_after, 0);
 
-        // Delete non-existent returns NotFound
         assert!(matches!(storage.delete("test"), Err(Error::NotFound(_))));
     }
 
@@ -1135,7 +930,6 @@ mod tests {
             ));
         }
 
-        // Verify all 3 messages stored
         let metadata = storage.head("test").unwrap();
         assert_eq!(metadata.message_count, 3);
     }
@@ -1146,7 +940,6 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // First append
         storage
             .append_with_producer(
                 "test",
@@ -1158,7 +951,6 @@ mod tests {
             )
             .unwrap();
 
-        // Duplicate
         let result = storage
             .append_with_producer(
                 "test",
@@ -1179,7 +971,6 @@ mod tests {
             }
         ));
 
-        // Only 1 message stored (not 2)
         let metadata = storage.head("test").unwrap();
         assert_eq!(metadata.message_count, 1);
     }
@@ -1201,7 +992,6 @@ mod tests {
             )
             .unwrap();
 
-        // Skip seq 1, send seq 2
         let err = storage
             .append_with_producer(
                 "test",
@@ -1228,7 +1018,6 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Establish epoch 1
         storage
             .append_with_producer(
                 "test",
@@ -1240,7 +1029,6 @@ mod tests {
             )
             .unwrap();
 
-        // Try with old epoch 0
         let err = storage
             .append_with_producer(
                 "test",
@@ -1267,7 +1055,6 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Epoch 0, seq 0..2
         for seq in 0..3 {
             storage
                 .append_with_producer(
@@ -1281,7 +1068,6 @@ mod tests {
                 .unwrap();
         }
 
-        // Bump to epoch 1 with seq 0
         let result = storage
             .append_with_producer(
                 "test",
@@ -1372,7 +1158,6 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Producer A seq 0
         storage
             .append_with_producer(
                 "test",
@@ -1384,7 +1169,6 @@ mod tests {
             )
             .unwrap();
 
-        // Producer B seq 0 (independent)
         storage
             .append_with_producer(
                 "test",
@@ -1396,7 +1180,6 @@ mod tests {
             )
             .unwrap();
 
-        // Producer A seq 1
         storage
             .append_with_producer(
                 "test",
@@ -1418,7 +1201,6 @@ mod tests {
         let config = StreamConfig::new("text/plain".to_string());
         storage.create_stream("test", config).unwrap();
 
-        // Append + close atomically
         storage
             .append_with_producer(
                 "test",
@@ -1430,7 +1212,6 @@ mod tests {
             )
             .unwrap();
 
-        // Send gap seq to closed stream — must get StreamClosed, not SequenceGap
         let err = storage
             .append_with_producer(
                 "test",

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod file;
 pub mod memory;
 
 use crate::protocol::error::Result;
@@ -16,7 +17,7 @@ use tokio::sync::broadcast;
 /// comparison therefore ignores `expires_at` in that case.  When
 /// `ttl_seconds` is `None` and `expires_at` was set directly (via
 /// `Expires-At` header), the parsed timestamp is stable so we compare it.
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StreamConfig {
     /// Content-Type header value (normalized, lowercase)
     pub content_type: String,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,11 +1,12 @@
 pub mod file;
 pub mod memory;
 
-use crate::protocol::error::Result;
+use crate::protocol::error::{Error, Result};
 use crate::protocol::offset::Offset;
 use crate::protocol::producer::ProducerHeaders;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use std::collections::HashMap;
 use tokio::sync::broadcast;
 
 /// Stream configuration
@@ -174,6 +175,145 @@ pub enum ProducerAppendResult {
         next_offset: Offset,
         closed: bool,
     },
+}
+
+// ── Shared constants and validation helpers ─────────────────────────
+//
+// Extracted from InMemoryStorage/FileStorage to avoid duplication.
+// Both implementations delegate to these for content-type, seq,
+// producer, and expiry validation.
+
+/// Duration after which stale producer state is cleaned up (7 days).
+pub(crate) const PRODUCER_STATE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+
+/// Broadcast channel capacity for long-poll/SSE notifications.
+/// Small because notifications are hints (no payload), not data delivery.
+pub(crate) const NOTIFY_CHANNEL_CAPACITY: usize = 16;
+
+/// Per-producer state tracked within a stream.
+///
+/// Shared between storage implementations. Includes serde derives
+/// for the file-backed storage which persists this to disk.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ProducerState {
+    pub epoch: u64,
+    pub last_seq: u64,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Outcome of producer validation before any mutation.
+pub(crate) enum ProducerCheck {
+    /// Request is valid; proceed with append.
+    Accept,
+    /// Request is a duplicate; return idempotent success.
+    Duplicate { epoch: u64, seq: u64 },
+}
+
+/// Check if a stream has expired based on its configuration.
+pub(crate) fn is_stream_expired(config: &StreamConfig) -> bool {
+    config
+        .expires_at
+        .is_some_and(|expires_at| Utc::now() >= expires_at)
+}
+
+/// Validate content-type matches the stream's configured type (case-insensitive).
+pub(crate) fn validate_content_type(stream_ct: &str, request_ct: &str) -> Result<()> {
+    if request_ct.to_lowercase() != stream_ct.to_lowercase() {
+        return Err(Error::ContentTypeMismatch {
+            expected: stream_ct.to_string(),
+            actual: request_ct.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate Stream-Seq ordering and return the pending value to commit.
+///
+/// Returns `Err(SeqOrderingViolation)` if the new seq is not strictly
+/// greater than the last seq (lexicographic comparison).
+pub(crate) fn validate_seq(
+    last_seq: Option<&str>,
+    new_seq: Option<&str>,
+) -> Result<Option<String>> {
+    if let Some(new) = new_seq {
+        if let Some(last) = last_seq
+            && new <= last
+        {
+            return Err(Error::SeqOrderingViolation {
+                last: last.to_string(),
+                received: new.to_string(),
+            });
+        }
+        return Ok(Some(new.to_string()));
+    }
+    Ok(None)
+}
+
+/// Remove producer state entries older than `PRODUCER_STATE_TTL_SECS`.
+pub(crate) fn cleanup_stale_producers(producers: &mut HashMap<String, ProducerState>) {
+    let cutoff = Utc::now()
+        - chrono::TimeDelta::try_seconds(PRODUCER_STATE_TTL_SECS)
+            .expect("7 days fits in TimeDelta");
+    producers.retain(|_, state| state.updated_at > cutoff);
+}
+
+/// Validate producer epoch/sequence against existing state.
+///
+/// Implements the standard validation order:
+///   1. Epoch fencing (403)
+///   2. Duplicate detection (204) — before closed check so retries work
+///   3. Closed check (409) — blocks new sequences on closed streams
+///   4. Gap / epoch-bump validation
+pub(crate) fn check_producer(
+    existing: Option<&ProducerState>,
+    producer: &ProducerHeaders,
+    stream_closed: bool,
+) -> Result<ProducerCheck> {
+    if let Some(state) = existing {
+        if producer.epoch < state.epoch {
+            return Err(Error::EpochFenced {
+                current: state.epoch,
+                received: producer.epoch,
+            });
+        }
+
+        if producer.epoch == state.epoch && producer.seq <= state.last_seq {
+            return Ok(ProducerCheck::Duplicate {
+                epoch: state.epoch,
+                seq: state.last_seq,
+            });
+        }
+
+        // Not a duplicate — if stream is closed, reject
+        if stream_closed {
+            return Err(Error::StreamClosed);
+        }
+
+        if producer.epoch > state.epoch {
+            if producer.seq != 0 {
+                return Err(Error::InvalidProducerState(
+                    "new epoch must start at seq 0".to_string(),
+                ));
+            }
+        } else if producer.seq > state.last_seq + 1 {
+            return Err(Error::SequenceGap {
+                expected: state.last_seq + 1,
+                actual: producer.seq,
+            });
+        }
+    } else {
+        // New producer
+        if stream_closed {
+            return Err(Error::StreamClosed);
+        }
+        if producer.seq != 0 {
+            return Err(Error::SequenceGap {
+                expected: 0,
+                actual: producer.seq,
+            });
+        }
+    }
+    Ok(ProducerCheck::Accept)
 }
 
 /// Storage trait for stream persistence


### PR DESCRIPTION
## Summary

- Adds a durable file storage backend (`FileStorage`) as an alternative to in-memory storage, using append-only segment files with WAL-style durability
- Introduces a comprehensive benchmark suite (Makefile targets) supporting both memory and file storage modes, with dual Rust/Node reference server targets
- Adds `STORAGE_MODE` config to switch between `memory` and `file` backends at startup

## Test plan

- [ ] `cargo test` — all existing unit + conformance tests pass with in-memory storage (default)
- [ ] `make benchmark-memory` — benchmark suite runs against in-memory backend
- [ ] `make benchmark-file` — benchmark suite runs against file storage backend
- [ ] `make benchmark-node` — benchmark suite runs against Node reference server
- [ ] Verify `STORAGE_MODE=file cargo run` starts server with file backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)