### PR TITLE
Bump conformance tests to 0.2.2

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -83,7 +83,7 @@ jobs:
           mkdir -p /tmp/conformance-run
           cd /tmp/conformance-run
           npm init -y
-          npm install @durable-streams/server-conformance-tests@0.2.1
+          npm install @durable-streams/server-conformance-tests@0.2.2
           cat > conformance.test.mjs << 'TESTEOF'
           import { runConformanceTests } from "@durable-streams/server-conformance-tests";
           runConformanceTests({ baseUrl: process.env.CONFORMANCE_TEST_URL, longPollTimeoutMs: 2000 });

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "durable-streams-reference"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "durable-streams-reference"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [lints.clippy]
@@ -8,7 +8,7 @@ pedantic = { level = "warn", priority = -1 }
 
 # Spec versions implemented:
 # - Spec SHA: a347312a47ae510a4a2e3ee7a121d6c8d7d74e50
-# - Conformance: 0.2.1
+# - Conformance: 0.2.2
 
 [dependencies]
 axum = { version = "0.8.8", features = ["macros"] }

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-integration:
 # Requires: node, npm
 # On first run, installs the conformance harness to /tmp/conformance-run
 CONFORMANCE_DIR := /tmp/conformance-run
-CONFORMANCE_VERSION := 0.2.1
+CONFORMANCE_VERSION := 0.2.2
 
 $(CONFORMANCE_DIR)/node_modules: $(CONFORMANCE_DIR)/package.json
 	cd $(CONFORMANCE_DIR) && npm install

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The latest benchmark matrix findings are in
 
 ## Conformance
 
-This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.1`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md).
+This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.2`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md).
 
 Run conformance tests locally:
 
@@ -70,7 +70,7 @@ DS_SERVER__LONG_POLL_TIMEOUT_SECS=2 DS_SERVER__SSE_RECONNECT_INTERVAL_SECS=5 car
 
 cd /tmp/conformance-run
 npm init -y
-npm install @durable-streams/server-conformance-tests@0.2.1
+npm install @durable-streams/server-conformance-tests@0.2.2
 cat > conformance.test.mjs << 'EOF'
 import { runConformanceTests } from "@durable-streams/server-conformance-tests";
 runConformanceTests({ baseUrl: process.env.CONFORMANCE_TEST_URL, longPollTimeoutMs: 2000 });

--- a/SPEC_VERSION.md
+++ b/SPEC_VERSION.md
@@ -17,7 +17,7 @@ and conformance test suite that this implementation targets.
 
 **Package:** `@durable-streams/server-conformance-tests`
 
-**Version:** `0.2.1`
+**Version:** `0.2.2`
 
 **NPM Registry:** https://www.npmjs.com/package/@durable-streams/server-conformance-tests
 

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -32,4 +32,4 @@ Together they implement the *durable sessions* pattern: real-time collaborative 
 
 ## Conformance
 
-This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.1`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md). All 239 conformance tests pass.
+This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.2`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md). All 239 conformance tests pass.

--- a/docs/book/src/project/governance.md
+++ b/docs/book/src/project/governance.md
@@ -20,7 +20,7 @@ This implementation strictly adheres to the durable streams protocol specificati
 The protocol spec is pinned by git commit SHA, not by branch. The conformance test suite is pinned by npm package version. See [`SPEC_VERSION.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/SPEC_VERSION.md) for current pins:
 
 - **Spec SHA:** `a347312a47ae510a4a2e3ee7a121d6c8d7d74e50`
-- **Conformance:** `@durable-streams/server-conformance-tests@0.2.1`
+- **Conformance:** `@durable-streams/server-conformance-tests@0.2.2`
 
 ## Traceability
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,14 +8,15 @@ and any behaviour differences or breaking changes.
 | Spec SHA | Server Version | Status | Notes | Breaking Changes |
 |----------|----------------|--------|-------|------------------|
 | a347312a47ae510a4a2e3ee7a121d6c8d7d74e50 | 0.1.0 | Complete | Full conformance with @durable-streams/server-conformance-tests@0.2.1 | N/A |
+| a347312a47ae510a4a2e3ee7a121d6c8d7d74e50 | 0.1.1 | Complete | Full conformance with @durable-streams/server-conformance-tests@0.2.2 | N/A |
 
 ## Current Implementation
 
-**Server Version:** 0.1.0
+**Server Version:** 0.1.1
 
 **Spec SHA:** a347312a47ae510a4a2e3ee7a121d6c8d7d74e50
 
-**Conformance Version:** 0.2.1
+**Conformance Version:** 0.2.2
 
 **Status:** Fully conformant. All 239 conformance tests pass.
 


### PR DESCRIPTION
## Summary
- Bumps `@durable-streams/server-conformance-tests` from 0.2.1 to 0.2.2 across all references (Makefile, CI, docs, SPEC_VERSION.md)
- Bumps crate version from 0.1.0 to 0.1.1
- Adds new row to `docs/compatibility.md` version history

## Test plan
- [x] Ran `make conformance` locally against 0.2.2 — 239/239 tests pass
- [ ] CI conformance workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)