### PR TITLE
Add crates.io publish metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "durable-streams-reference"
 version = "0.1.1"
 edition = "2024"
+description = "Reference implementation of the Durable Streams protocol in Rust, built with axum and tokio"
+license = "MIT"
+repository = "https://github.com/thesampaton/durable-streams-reference"
+homepage = "https://thesampaton.github.io/durable-streams-reference/"
+readme = "README.md"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ license = "MIT"
 repository = "https://github.com/thesampaton/durable-streams-reference"
 homepage = "https://thesampaton.github.io/durable-streams-reference/"
 readme = "README.md"
+keywords = ["streaming", "event-sourcing", "durable-streams", "sse", "long-polling"]
+categories = ["web-programming::http-server", "network-programming"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://thesampaton.github.io/durable-streams-reference/"
 readme = "README.md"
 keywords = ["streaming", "event-sourcing", "durable-streams", "sse", "long-polling"]
 categories = ["web-programming::http-server", "network-programming"]
+exclude = [".agents/", ".claude/", ".github/", "docs/", "specs/", "tests/", "scratch/", "e2e/", "scripts/", "docker-compose.yml", "Dockerfile", "Makefile", ".dockerignore"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }


### PR DESCRIPTION
## Summary
- Add required publish metadata to Cargo.toml: description, license, repository, homepage, and readme

## Test plan
- [x] `cargo check` passes