### PR TITLE
Rename crate to durable-streams-rust-server

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: server-binary
-          path: target/debug/durable-streams-reference
+          path: target/debug/durable-streams-rust-server
 
   conformance:
     name: Protocol Conformance Tests
@@ -67,8 +67,8 @@ jobs:
 
       - name: Start server
         run: |
-          chmod +x durable-streams-reference
-          ./durable-streams-reference &
+          chmod +x durable-streams-rust-server
+          ./durable-streams-rust-server &
         env:
           DS_SERVER__LONG_POLL_TIMEOUT_SECS: '2'
           DS_SERVER__SSE_RECONNECT_INTERVAL_SECS: '5'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: server-binary
-          path: target/debug/durable-streams-rust-server
+          path: target/debug/durable-streams-server
 
   conformance:
     name: Protocol Conformance Tests
@@ -67,8 +67,8 @@ jobs:
 
       - name: Start server
         run: |
-          chmod +x durable-streams-rust-server
-          ./durable-streams-rust-server &
+          chmod +x durable-streams-server
+          ./durable-streams-server &
         env:
           DS_SERVER__LONG_POLL_TIMEOUT_SECS: '2'
           DS_SERVER__SSE_RECONNECT_INTERVAL_SECS: '5'

--- a/.github/workflows/pgo-release.yml
+++ b/.github/workflows/pgo-release.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           name: durable-streams-pgo-release
           path: |
-            target/release/durable-streams-reference
+            target/release/durable-streams-rust-server
             /tmp/ds-pgo/merged.profdata
             /tmp/benchmark-run/benchmark-results-pgo-memory.json
             /tmp/benchmark-run/benchmark-results-pgo-file.json

--- a/.github/workflows/pgo-release.yml
+++ b/.github/workflows/pgo-release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           name: durable-streams-pgo-release
           path: |
-            target/release/durable-streams-rust-server
+            target/release/durable-streams-server
             /tmp/ds-pgo/merged.profdata
             /tmp/benchmark-run/benchmark-results-pgo-memory.json
             /tmp/benchmark-run/benchmark-results-pgo-file.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,6 @@ dependencies = [
  "chrono",
  "figment",
  "futures-util",
- "rand",
  "redb",
  "reqwest",
  "rustls",
@@ -324,7 +323,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-test",
- "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1104,15 +1102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,35 +1140,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "redb"
@@ -2357,26 +2317,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "durable-streams-rust-server"
+name = "durable-streams-server"
 version = "0.1.1"
 dependencies = [
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "durable-streams-reference"
+name = "durable-streams-rust-server"
 version = "0.1.1"
 dependencies = [
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "durable-streams-rust-server"
+name = "durable-streams-server"
 version = "0.1.1"
 edition = "2024"
 description = "Durable Streams protocol server in Rust, built with axum and tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "durable-streams-reference"
+name = "durable-streams-rust-server"
 version = "0.1.1"
 edition = "2024"
-description = "Reference implementation of the Durable Streams protocol in Rust, built with axum and tokio"
+description = "Durable Streams protocol server in Rust, built with axum and tokio"
 license = "MIT"
-repository = "https://github.com/thesampaton/durable-streams-reference"
-homepage = "https://thesampaton.github.io/durable-streams-reference/"
+repository = "https://github.com/thesampaton/durable-streams-rust-server"
+homepage = "https://thesampaton.github.io/durable-streams-rust-server/"
 readme = "README.md"
 keywords = ["streaming", "event-sourcing", "durable-streams", "sse", "long-polling"]
 categories = ["web-programming::http-server", "network-programming"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://thesampaton.github.io/durable-streams-rust-server/"
 readme = "README.md"
 keywords = ["streaming", "event-sourcing", "durable-streams", "sse", "long-polling"]
 categories = ["web-programming::http-server", "network-programming"]
-exclude = [".agents/", ".claude/", ".github/", "docs/", "specs/", "scratch/", "e2e/", "scripts/", "docker-compose.yml", "Dockerfile", "Makefile", ".dockerignore"]
+exclude = [".agents/", ".claude/", ".github/", "docs/", "specs/", "scratch/", "e2e/", "scripts/", "docker-compose.yml", "Dockerfile", "Makefile", ".dockerignore", "CLAUDE.md", "**/CLAUDE.md"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -24,7 +24,6 @@ tokio = { version = "1.50", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-tower = "0.5.3"
 tower-http = { version = "0.6.8", features = ["cors"] }
 bytes = "1.11"
 base64 = "0.22.1"
@@ -32,7 +31,6 @@ chrono = { version = "0.4.44", features = ["serde"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 axum-server = { version = "0.7.3", features = ["tls-rustls"] }
-rand = "0.9.2"
 async-stream = "0.3.6"
 futures-util = "0.3.32"
 redb = "3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN touch src/main.rs src/lib.rs && cargo build --release
 # Stage 2: Runtime
 FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /build/target/release/durable-streams-rust-server /durable-streams-server
+COPY --from=builder /build/target/release/durable-streams-server /durable-streams-server
 
 EXPOSE 4437
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN touch src/main.rs src/lib.rs && cargo build --release
 # Stage 2: Runtime
 FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /build/target/release/durable-streams-reference /durable-streams-server
+COPY --from=builder /build/target/release/durable-streams-rust-server /durable-streams-server
 
 EXPOSE 4437
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# durable-streams-reference
+# durable-streams-rust-server
 
-[![CI](https://github.com/thesampaton/durable-streams-reference/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-reference/actions/workflows/ci.yml)
-[![Conformance](https://github.com/thesampaton/durable-streams-reference/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-reference/actions/workflows/conformance.yml)
+[![CI](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml)
+[![Conformance](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml)
 
-Reference implementation of the [durable streams protocol](https://github.com/durable-streams/durable-streams) in rust, with idiomatic approaches to fulfilling the protocol specification and near-parity with the caddy production implementation. This project exists to validate ai-enabled development approaches, to pressure test the durable streams approach and to document how to deliver an end to end solution with durable streams, electric sql and postgres, using the gatekeeper auth pattern.
+Rust implementation of the [durable streams protocol](https://github.com/durable-streams/durable-streams), with idiomatic approaches to fulfilling the protocol specification and feature parity with the caddy implementation. This project exists to validate ai-enabled development approaches, to pressure test the durable streams approach and to document how to deliver an end to end solution with durable streams, electric sql and postgres, using the gatekeeper auth pattern.
 
-Documents https://thesampaton.github.io/durable-streams-reference/
+Documents https://thesampaton.github.io/durable-streams-rust-server/
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/ci.yml)
 [![Conformance](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/thesampaton/durable-streams-rust-server/actions/workflows/conformance.yml)
 
+Published crate: `durable-streams-server`. Repository: `durable-streams-rust-server`.
+
 Rust implementation of the [durable streams protocol](https://github.com/durable-streams/durable-streams), with idiomatic approaches to fulfilling the protocol specification and feature parity with the caddy implementation. This project exists to validate ai-enabled development approaches, to pressure test the durable streams approach and to document how to deliver an end to end solution with durable streams, electric sql and postgres, using the gatekeeper auth pattern.
 
 Documents https://thesampaton.github.io/durable-streams-rust-server/

--- a/docs/book/src/project/contributing.md
+++ b/docs/book/src/project/contributing.md
@@ -3,8 +3,8 @@
 ## Development setup
 
 ```bash
-git clone https://github.com/thesampaton/durable-streams-reference.git
-cd durable-streams-reference
+git clone https://github.com/thesampaton/durable-streams-rust-server.git
+cd durable-streams-rust-server
 cargo build
 cargo test
 ```
@@ -78,4 +78,4 @@ so artifacts are built from current benchmark-driven profiles.
 
 ## Protocol governance
 
-All protocol-level decisions must comply with the governance policies in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/protocol-governance.md). Key rule: never invent semantics. If it is not in spec or tests, record it as a gap.
+All protocol-level decisions must comply with the governance policies in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/protocol-governance.md). Key rule: never invent semantics. If it is not in spec or tests, record it as a gap.

--- a/docs/book/src/project/decisions.md
+++ b/docs/book/src/project/decisions.md
@@ -1,6 +1,6 @@
 # Decision log
 
-Implementation decisions are recorded in [`docs/decisions.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/decisions.md) in three sections: **Protocol**, **Architecture**, and **Operational**.
+Implementation decisions are recorded in [`docs/decisions.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/decisions.md) in three sections: **Protocol**, **Architecture**, and **Operational**.
 
 ## Current protocol decisions
 
@@ -39,4 +39,4 @@ Each decision in the full log includes:
 4. **Rationale:** why this choice was made
 5. **Date:** when the decision was made
 
-When ambiguous on protocol behavior, decisions reference the corresponding gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/gaps.md).
+When ambiguous on protocol behavior, decisions reference the corresponding gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/gaps.md).

--- a/docs/book/src/project/gaps.md
+++ b/docs/book/src/project/gaps.md
@@ -1,6 +1,6 @@
 # Spec gaps
 
-Ambiguities and edge cases not fully covered by the protocol spec or conformance tests are recorded in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/gaps.md). This page summarizes the current gaps and known ecosystem interop observations.
+Ambiguities and edge cases not fully covered by the protocol spec or conformance tests are recorded in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/gaps.md). This page summarizes the current gaps and known ecosystem interop observations.
 
 ## Active gaps
 
@@ -10,11 +10,11 @@ Ambiguities and edge cases not fully covered by the protocol spec or conformance
 
 Gaps are not failures. They are explicit acknowledgments that the implementation operates beyond the spec's current coverage.
 
-Non-protocol architecture and operational decisions are tracked in [`docs/decisions.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/decisions.md).
+Non-protocol architecture and operational decisions are tracked in [`docs/decisions.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/decisions.md).
 
 ## Ecosystem interop observations
 
-These are recorded in [`docs/ecosystem-interop.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/ecosystem-interop.md). They are not protocol gaps -- the protocol is fine. They are rough edges in ecosystem components that developers encounter during integration.
+These are recorded in [`docs/ecosystem-interop.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/ecosystem-interop.md). They are not protocol gaps -- the protocol is fine. They are rough edges in ecosystem components that developers encounter during integration.
 
 | ID | Summary | Component |
 |----|---------|-----------|

--- a/docs/book/src/project/governance.md
+++ b/docs/book/src/project/governance.md
@@ -1,6 +1,6 @@
 # Protocol governance
 
-This implementation strictly adheres to the durable streams protocol specification. This page summarizes the governance policies defined in full in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/protocol-governance.md).
+This implementation strictly adheres to the durable streams protocol specification. This page summarizes the governance policies defined in full in [`docs/protocol-governance.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/protocol-governance.md).
 
 ## Default stance
 
@@ -17,7 +17,7 @@ This implementation strictly adheres to the durable streams protocol specificati
 
 ## Spec pinning
 
-The protocol spec is pinned by git commit SHA, not by branch. The conformance test suite is pinned by npm package version. See [`SPEC_VERSION.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/SPEC_VERSION.md) for current pins:
+The protocol spec is pinned by git commit SHA, not by branch. The conformance test suite is pinned by npm package version. See [`SPEC_VERSION.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/SPEC_VERSION.md) for current pins:
 
 - **Spec SHA:** `a347312a47ae510a4a2e3ee7a121d6c8d7d74e50`
 - **Conformance:** `@durable-streams/server-conformance-tests@0.2.2`
@@ -27,7 +27,7 @@ The protocol spec is pinned by git commit SHA, not by branch. The conformance te
 Every externally observable behavior (paths, headers, status codes, framing) must link to:
 - A spec section URL with anchor, or
 - A conformance test that asserts it, or
-- An explicit gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-reference/blob/trunk/docs/gaps.md)
+- An explicit gap in [`docs/gaps.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/docs/gaps.md)
 
 ## Conservative fallback rules
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use axum_server::{Handle, tls_rustls::RustlsConfig};
-use durable_streams_rust_server::{
+use durable_streams_server::{
     config::{Config, ConfigLoadOptions, StorageMode},
     router,
     storage::{Storage, acid::AcidStorage, file::FileStorage, memory::InMemoryStorage},
@@ -59,7 +59,7 @@ impl CliArgs {
 }
 
 fn print_usage() {
-    eprintln!("Usage: durable-streams-rust-server [--profile <name>] [--config <path>]");
+    eprintln!("Usage: durable-streams-server [--profile <name>] [--config <path>]");
     eprintln!("  --profile <name>  Loads config/<name>.toml after config/default.toml");
     eprintln!("  --config <path>   Loads an extra TOML override file last");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use axum_server::{Handle, tls_rustls::RustlsConfig};
-use durable_streams_reference::{
+use durable_streams_rust_server::{
     config::{Config, ConfigLoadOptions, StorageMode},
     router,
     storage::{Storage, acid::AcidStorage, file::FileStorage, memory::InMemoryStorage},
@@ -59,7 +59,7 @@ impl CliArgs {
 }
 
 fn print_usage() {
-    eprintln!("Usage: durable-streams-reference [--profile <name>] [--config <path>]");
+    eprintln!("Usage: durable-streams-rust-server [--profile <name>] [--config <path>]");
     eprintln!("  --profile <name>  Loads config/<name>.toml after config/default.toml");
     eprintln!("  --config <path>   Loads an extra TOML override file last");
 }

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -54,7 +54,7 @@ scaffolding. The external conformance suite is the ultimate acceptance gate.
 ## Black-Box Testing Requirement
 
 Integration tests MUST NOT:
-- Import server modules directly (no `use durable_streams_rust_server::*`)
+- Import server modules directly (no `use durable_streams_server::*`)
 - Inspect internal state (no accessing storage directly)
 - Mock server behaviour (no fake servers, use the real binary)
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -54,7 +54,7 @@ scaffolding. The external conformance suite is the ultimate acceptance gate.
 ## Black-Box Testing Requirement
 
 Integration tests MUST NOT:
-- Import server modules directly (no `use durable_streams_reference::*`)
+- Import server modules directly (no `use durable_streams_rust_server::*`)
 - Inspect internal state (no accessing storage directly)
 - Mock server behaviour (no fake servers, use the real binary)
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,11 +2,11 @@
 // Shared across many independent integration-test crates; each crate only uses
 // a subset of helpers, so items appear unused when compiled per-test target.
 
-use durable_streams_rust_server::config::{Config, StorageMode};
-use durable_streams_rust_server::protocol::error::Result;
-use durable_streams_rust_server::protocol::offset::Offset;
-use durable_streams_rust_server::protocol::producer::ProducerHeaders;
-use durable_streams_rust_server::storage::{
+use durable_streams_server::config::{Config, StorageMode};
+use durable_streams_server::protocol::error::Result;
+use durable_streams_server::protocol::offset::Offset;
+use durable_streams_server::protocol::producer::ProducerHeaders;
+use durable_streams_server::storage::{
     CreateStreamResult, CreateWithDataResult, ProducerAppendResult, ReadResult, Storage,
     StreamConfig, StreamMetadata, acid::AcidStorage, file::FileStorage, memory::InMemoryStorage,
 };
@@ -341,7 +341,7 @@ where
     let port = addr.port();
 
     // Build and spawn server
-    let app = durable_streams_rust_server::router::build_router(storage, &config);
+    let app = durable_streams_server::router::build_router(storage, &config);
 
     tokio::spawn(async move {
         axum::serve(listener, app)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,11 +2,11 @@
 // Shared across many independent integration-test crates; each crate only uses
 // a subset of helpers, so items appear unused when compiled per-test target.
 
-use durable_streams_reference::config::{Config, StorageMode};
-use durable_streams_reference::protocol::error::Result;
-use durable_streams_reference::protocol::offset::Offset;
-use durable_streams_reference::protocol::producer::ProducerHeaders;
-use durable_streams_reference::storage::{
+use durable_streams_rust_server::config::{Config, StorageMode};
+use durable_streams_rust_server::protocol::error::Result;
+use durable_streams_rust_server::protocol::offset::Offset;
+use durable_streams_rust_server::protocol::producer::ProducerHeaders;
+use durable_streams_rust_server::storage::{
     CreateStreamResult, CreateWithDataResult, ProducerAppendResult, ReadResult, Storage,
     StreamConfig, StreamMetadata, acid::AcidStorage, file::FileStorage, memory::InMemoryStorage,
 };
@@ -341,7 +341,7 @@ where
     let port = addr.port();
 
     // Build and spawn server
-    let app = durable_streams_reference::router::build_router(storage, &config);
+    let app = durable_streams_rust_server::router::build_router(storage, &config);
 
     tokio::spawn(async move {
         axum::serve(listener, app)

--- a/tests/storage_backend_contract.rs
+++ b/tests/storage_backend_contract.rs
@@ -2,10 +2,10 @@ mod common;
 
 use bytes::Bytes;
 use common::{StorageTestBackend, create_test_storage, create_test_storage_with_limits};
-use durable_streams_reference::protocol::error::Error;
-use durable_streams_reference::protocol::offset::Offset;
-use durable_streams_reference::protocol::producer::ProducerHeaders;
-use durable_streams_reference::storage::{
+use durable_streams_rust_server::protocol::error::Error;
+use durable_streams_rust_server::protocol::offset::Offset;
+use durable_streams_rust_server::protocol::producer::ProducerHeaders;
+use durable_streams_rust_server::storage::{
     CreateStreamResult, ProducerAppendResult, Storage, StreamConfig,
 };
 use std::panic::{AssertUnwindSafe, RefUnwindSafe, catch_unwind};

--- a/tests/storage_backend_contract.rs
+++ b/tests/storage_backend_contract.rs
@@ -2,10 +2,10 @@ mod common;
 
 use bytes::Bytes;
 use common::{StorageTestBackend, create_test_storage, create_test_storage_with_limits};
-use durable_streams_rust_server::protocol::error::Error;
-use durable_streams_rust_server::protocol::offset::Offset;
-use durable_streams_rust_server::protocol::producer::ProducerHeaders;
-use durable_streams_rust_server::storage::{
+use durable_streams_server::protocol::error::Error;
+use durable_streams_server::protocol::offset::Offset;
+use durable_streams_server::protocol::producer::ProducerHeaders;
+use durable_streams_server::storage::{
     CreateStreamResult, ProducerAppendResult, Storage, StreamConfig,
 };
 use std::panic::{AssertUnwindSafe, RefUnwindSafe, catch_unwind};

--- a/tests/tls_transport.rs
+++ b/tests/tls_transport.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum_server::{from_tcp_rustls, tls_rustls::RustlsConfig};
 use common::test_client;
-use durable_streams_reference::{config::Config, router, storage::memory::InMemoryStorage};
+use durable_streams_rust_server::{config::Config, router, storage::memory::InMemoryStorage};
 use rustls::{ClientConfig, RootCertStore, pki_types::ServerName};
 use rustls_pemfile::certs;
 use std::io::BufReader;

--- a/tests/tls_transport.rs
+++ b/tests/tls_transport.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum_server::{from_tcp_rustls, tls_rustls::RustlsConfig};
 use common::test_client;
-use durable_streams_rust_server::{config::Config, router, storage::memory::InMemoryStorage};
+use durable_streams_server::{config::Config, router, storage::memory::InMemoryStorage};
 use rustls::{ClientConfig, RootCertStore, pki_types::ServerName};
 use rustls_pemfile::certs;
 use std::io::BufReader;


### PR DESCRIPTION
## Summary

- Renames crate from `durable-streams-reference` to `durable-streams-rust-server` across all 15 files (Cargo.toml, source, tests, CI workflows, Dockerfile, docs)
- Updates description from "Reference implementation" to "Durable Streams protocol server"
- Updates README intro to reflect feature parity with caddy implementation

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test --lib` — 91 unit tests pass
- [x] `cargo test --test '*'` — integration tests pass
- [x] `cargo fmt` — no changes
- [x] Grep confirms zero remaining references to old name