### PR TITLE
Documentation audit: fix stale references across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ cargo run
 
 The server listens on `http://localhost:4437` with streams at `/v1/stream/`.
 
+## Storage backends
+
+The default storage mode is in-memory. For persistence, choose a backend via `DS_STORAGE__MODE`:
+
+| Mode | Durability | Use case |
+|------|-----------|----------|
+| `memory` | None (lost on restart) | Development, testing, buffer in front of sync layer |
+| `file-fast` | Buffered writes | Low-latency persistence where occasional data loss is acceptable |
+| `file-durable` | Fsynced writes | Durable persistence without external dependencies |
+| `acid` (alias: `redb`) | Crash-resilient (redb) | Production workloads requiring ACID guarantees |
+
+```bash
+# Run with durable file storage
+DS_STORAGE__MODE=file-durable DS_STORAGE__DATA_DIR=./data cargo run
+
+# Run with crash-resilient acid storage
+DS_STORAGE__MODE=acid DS_STORAGE__DATA_DIR=./data cargo run
+```
+
 ## Build and test
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -137,4 +137,5 @@ Environment variables use `DS_` prefix with double-underscore section separators
 | `DS_STORAGE__ACID_SHARD_COUNT` | `16` | Number of redb shards for acid mode (power-of-2, `1..=256`) |
 | `DS_TLS__CERT_PATH` | _(unset)_ | Optional PEM certificate path for direct TLS termination (requires `DS_TLS__KEY_PATH`) |
 | `DS_TLS__KEY_PATH` | _(unset)_ | Optional PEM/PKCS#8 key path for direct TLS termination (requires `DS_TLS__CERT_PATH`) |
-| `RUST_LOG` | `info` | Log level filter (standard tracing env var) |
+| `DS_LOG__RUST_LOG` | `info` | Default log level filter (via TOML config layer) |
+| `RUST_LOG` | `info` | Log level filter (standard tracing env var, takes precedence over `DS_LOG__RUST_LOG`) |

--- a/docs/book/src/architecture/overview.md
+++ b/docs/book/src/architecture/overview.md
@@ -22,9 +22,9 @@ The full deployment has five components. Each solves one problem and composes cl
 
 | Component | Problem it solves |
 |-----------|-------------------|
-| **DS server** | Real-time append-only log with SSE, offset resumption, and producer idempotency. Stores streams in memory, delivers data fast. |
+| **DS server** | Real-time append-only log with SSE, offset resumption, and producer idempotency. Configurable storage (memory, file, acid/redb). |
 | **Envoy proxy** | JWT authentication. The DS server has no auth, so Envoy validates tokens and forwards the `sub` claim as `X-JWT-Sub`. |
-| **Postgres** | Durable storage. Streams in memory survive as long as the server runs; Postgres survives restarts. |
+| **Postgres** | Durable storage and SQL querying. Even with persistent storage modes, Postgres provides structured access, analytics, and cross-service visibility. |
 | **Electric SQL** | Change data capture. Reads the Postgres WAL and exposes a Shape API that delivers table changes as a stream. |
 | **Sync service** | Bidirectional bridge. Forwards Postgres changes into DS streams (PG-to-Stream) and DS stream events into Postgres (Stream-to-PG). |
 
@@ -51,7 +51,7 @@ A client appends a session event (chat message, presence update) to a DS stream.
 The architecture is composable. Each piece can be replaced independently:
 
 - **Auth proxy:** Envoy is one option. Any reverse proxy that validates JWTs and forwards claims works (nginx, Caddy, cloud load balancers).
-- **Storage:** The DS server uses in-memory storage. A persistent backend (Redis, SQLite, Postgres-backed) could replace it without changing the protocol.
+- **Storage:** The DS server supports in-memory, file-based, and acid (redb) storage backends, configurable via `DS_STORAGE__MODE`.
 - **Sync layer:** Electric SQL is the reference CDC tool. Any WAL reader (Debezium, custom logical replication) could feed the sync service.
 - **Database:** Postgres is used here because Electric requires it. The sync service pattern works with any database that supports change notifications.
 

--- a/docs/book/src/architecture/server.md
+++ b/docs/book/src/architecture/server.md
@@ -26,7 +26,7 @@ The durable streams server is the core component. It implements the [durable str
 
 ## Configuration
 
-The server is configured entirely through environment variables. See [Configuration](../reference/configuration.md) for the full list.
+The server is configured through layered TOML files and environment variables. See [Configuration](../reference/configuration.md) for the full list.
 
 Key defaults:
 

--- a/docs/book/src/architecture/sync.md
+++ b/docs/book/src/architecture/sync.md
@@ -1,6 +1,6 @@
 # Sync layer
 
-The DS server stores streams in memory. For durable storage and SQL querying, you need a sync layer that bridges DS streams and a database bidirectionally.
+The DS server supports multiple storage backends (memory, file, acid/redb). For SQL querying and cross-service visibility, you need a sync layer that bridges DS streams and a database bidirectionally.
 
 ## The pattern
 

--- a/docs/book/src/deployment/production.md
+++ b/docs/book/src/deployment/production.md
@@ -51,7 +51,7 @@ Tune the server's memory limits for your workload:
 | `DS_LIMITS__MAX_MEMORY_BYTES` | 100 MB | Total across all streams |
 | `DS_LIMITS__MAX_STREAM_BYTES` | 10 MB | Per stream |
 
-In production with the sync layer, streams are consumed and can be deleted after sync. The in-memory store acts as a buffer, not long-term storage.
+In production with the sync layer, streams are consumed and can be deleted after sync. When using the default in-memory mode, the store acts as a buffer, not long-term storage. For persistence without the sync layer, use `file-durable` or `acid` mode.
 
 ## Monitoring
 

--- a/docs/book/src/integration/client-app.md
+++ b/docs/book/src/integration/client-app.md
@@ -50,7 +50,7 @@ for await (const item of res.subscribeJson()) {
 }
 ```
 
-See [ecosystem interop CI-001](../project/gaps.md) for why this hint is necessary.
+See [ecosystem interop CI-001](../project/gaps.md#ecosystem-interop-observations) for why this hint is necessary.
 
 ## Using plain fetch
 

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -14,7 +14,7 @@ A durable stream is an append-only log exposed over HTTP. Clients create streams
 
 This repository contains two things:
 
-1. **A protocol server** written in Rust (axum + tokio). It passes the full conformance test suite and stores streams in memory. It has no authentication, no database, and no opinions about deployment. It is the simplest correct implementation of the protocol.
+1. **A protocol server** written in Rust (axum + tokio). It passes the full conformance test suite and supports multiple storage backends (in-memory, file-based, and crash-resilient acid/redb). It has no authentication, no database dependency, and no opinions about deployment.
 
 2. **A full deployment stack** that shows how to compose the server with real infrastructure:
    - **Envoy** as a JWT auth proxy in front of the server

--- a/docs/book/src/protocol/json-mode.md
+++ b/docs/book/src/protocol/json-mode.md
@@ -72,7 +72,7 @@ const parsed = JSON.parse(data);
 const items = Array.isArray(parsed) ? parsed : [parsed];
 ```
 
-See [ecosystem interop CI-003](../project/gaps.md) for details on this pattern.
+See [ecosystem interop CI-003](../project/gaps.md#ecosystem-interop-observations) for details on this pattern.
 
 ## Non-JSON streams
 

--- a/docs/book/src/protocol/streams.md
+++ b/docs/book/src/protocol/streams.md
@@ -10,7 +10,7 @@ curl -i -X PUT -H "Content-Type: text/plain" \
 ```
 
 **Headers:**
-- `Content-Type` (required): the stream's content type, fixed at creation
+- `Content-Type` (optional): the stream's content type, fixed at creation. Defaults to `application/octet-stream` if omitted
 - `Stream-TTL` (optional): time-to-live in seconds
 - `Stream-Expires-At` (optional): absolute expiration (ISO 8601)
 - `Stream-Closed` (optional): `"true"` to create in closed state
@@ -19,7 +19,7 @@ curl -i -X PUT -H "Content-Type: text/plain" \
 - `201 Created` with `Location`, `Content-Type`, `Stream-Next-Offset`
 - `200 OK` if the stream already exists with the same configuration (idempotent)
 - `409 Conflict` if the stream exists with different configuration
-- `400 Bad Request` for invalid TTL, missing Content-Type, or non-empty body
+- `400 Bad Request` for invalid TTL or empty Content-Type header
 
 The Content-Type is immutable after creation. Comparison is case-insensitive and ignores charset parameters.
 

--- a/docs/book/src/quickstart.md
+++ b/docs/book/src/quickstart.md
@@ -127,6 +127,17 @@ curl -i -X DELETE http://localhost:4437/v1/stream/my-stream
 HTTP/1.1 204 No Content
 ```
 
+## Persistent storage
+
+The quickstart uses in-memory storage (the default). For persistence, set `DS_STORAGE__MODE`:
+
+```bash
+# Crash-resilient storage using redb
+DS_STORAGE__MODE=acid DS_STORAGE__DATA_DIR=./data cargo run
+```
+
+Available modes: `memory`, `file-fast`, `file-durable`, `acid` (alias: `redb`). See [Configuration](reference/configuration.md) for details.
+
 ## Next steps
 
 - [Architecture overview](architecture/overview.md) to understand the full stack

--- a/docs/book/src/reference/api.md
+++ b/docs/book/src/reference/api.md
@@ -20,19 +20,19 @@ PUT /v1/stream/{name}
 
 | Header | Required | Description |
 |--------|----------|-------------|
-| `Content-Type` | yes | Stream content type (immutable after creation) |
+| `Content-Type` | no | Stream content type (immutable after creation; defaults to `application/octet-stream`) |
 | `Stream-TTL` | no | Time-to-live in seconds |
 | `Stream-Expires-At` | no | Absolute expiration (ISO 8601) |
 | `Stream-Closed` | no | `"true"` to create closed |
 
-Body must be empty.
+Body is optional. If provided, it is appended as initial stream data.
 
 | Status | Meaning |
 |--------|---------|
 | `201 Created` | Stream created |
 | `200 OK` | Idempotent create (same config) |
 | `409 Conflict` | Stream exists with different config |
-| `400 Bad Request` | Invalid TTL, missing Content-Type, non-empty body |
+| `400 Bad Request` | Invalid TTL or empty Content-Type header |
 
 **Response headers:** `Location`, `Content-Type`, `Stream-Next-Offset`
 

--- a/docs/book/src/reference/configuration.md
+++ b/docs/book/src/reference/configuration.md
@@ -38,7 +38,8 @@ Environment variables use the `DS_` prefix with double-underscore section separa
 |----------|---------|-------------|
 | `DS_SERVER__PORT` | `4437` | TCP port to listen on |
 | `DS_HTTP__CORS_ORIGINS` | `*` | Allowed CORS origins. `*` allows all. Multiple origins can be comma-separated (e.g., `https://app.example.com,https://admin.example.com`). |
-| `RUST_LOG` | `info` | Log level filter ([tracing](https://docs.rs/tracing-subscriber) format: `debug`, `info`, `warn`, `error`, or per-module like `durable_streams=debug`) |
+| `RUST_LOG` | `info` | Log level filter ([tracing](https://docs.rs/tracing-subscriber) format: `debug`, `info`, `warn`, `error`, or per-module like `durable_streams=debug`). Takes precedence over `DS_LOG__RUST_LOG`. |
+| `DS_LOG__RUST_LOG` | `info` | Default log level filter, applied through the TOML config layer. Overridden by `RUST_LOG` when both are set. |
 
 ## Transport (optional direct TLS)
 
@@ -67,7 +68,7 @@ Environment variables use the `DS_` prefix with double-underscore section separa
 |----------|---------|-------------|
 | `DS_STORAGE__MODE` | `memory` | Storage backend mode: `memory`, `file-fast`, `file-durable`, `acid` (alias: `redb`). |
 | `DS_STORAGE__DATA_DIR` | `./data/streams` | Root directory for persistent backends (`file-*`, `acid`). |
-| `DS_STORAGE__ACID_SHARD_COUNT` | `16` | Number of redb shards when `DS_STORAGE__MODE=acid`; must be power-of-2 in `1..=256` (invalid values fall back to `16`). |
+| `DS_STORAGE__ACID_SHARD_COUNT` | `16` | Number of redb shards when `DS_STORAGE__MODE=acid`; must be power-of-2 in `1..=256` (invalid values return an error). |
 
 ## Sync service (e2e stack)
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -22,7 +22,7 @@ and any behaviour differences or breaking changes.
 
 ## Conformance Coverage
 
-As of 2026-02-09:
+As of 2026-03-20:
 - Passing: 239/239 tests
 
 ## Known Limitations

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -27,7 +27,7 @@ As of 2026-02-09:
 
 ## Known Limitations
 
-- Storage is in-memory only (no persistence across restarts).
+- Default storage is in-memory. File-based (`file-fast`, `file-durable`) and crash-resilient (`acid`/redb) backends are available via `DS_STORAGE__MODE`.
 - See `docs/gaps.md` for spec ambiguities and chosen interpretations.
 
 ## Future Compatibility

--- a/docs/sessions-architecture.md
+++ b/docs/sessions-architecture.md
@@ -38,7 +38,7 @@ Neither direction is optional:
 
 ### DS server
 
-The protocol server. Stores streams in memory, delivers data via HTTP GET
+The protocol server. Stores streams using a configurable backend (memory, file, or acid/redb), delivers data via HTTP GET
 (catch-up), long-poll, or SSE. Does not understand session semantics — it
 treats all payloads as opaque bytes (or opaque JSON objects for JSON-mode
 streams).
@@ -301,8 +301,8 @@ docker-compose --profile sync down
 This harness is a local development and testing tool. For production:
 
 - **Auth:** Replace the test JWKS with a real identity provider.
-- **Persistence:** The DS server stores streams in memory. For durability
-  beyond the Stream→PG sync, consider a persistent storage backend.
+- **Persistence:** The DS server defaults to in-memory storage. For durability
+  beyond the Stream→PG sync, use `file-durable` or `acid` storage mode via `DS_STORAGE__MODE`.
 - **Electric config:** Pin the Electric SQL version and configure
   replication slots carefully. See `docs/ecosystem-interop.md` CI-004.
 - **Sync service resilience:** The sync service should track its SSE

--- a/specs/01-stream-lifecycle.md
+++ b/specs/01-stream-lifecycle.md
@@ -14,12 +14,12 @@ Defines stream lifecycle operations: creation (PUT), deletion (DELETE), and meta
 **Method:** `PUT /v1/stream/{name}`
 
 **Headers:**
-- `Content-Type` (required): Stream content type (e.g., `text/plain`, `application/json`)
+- `Content-Type` (optional): Stream content type (e.g., `text/plain`, `application/json`). Defaults to `application/octet-stream` if omitted.
 - `Stream-TTL` (optional): Time-to-live in seconds (integer, no leading zeros)
 - `Stream-Expires-At` (optional): Absolute expiration timestamp (ISO 8601)
 - `Stream-Closed` (optional): If `"true"`, create stream in closed state
 
-**Body:** MUST be empty. PUT with body MUST return 400.
+**Body:** Optional. If provided, the body is appended as initial stream data.
 
 ### Response
 
@@ -36,8 +36,7 @@ Defines stream lifecycle operations: creation (PUT), deletion (DELETE), and meta
 **400 Bad Request** - Invalid request:
 - Both TTL and Expires-At provided
 - Invalid TTL format (leading zeros, floats, scientific notation, negative)
-- Empty or missing Content-Type
-- Non-empty request body
+- Empty Content-Type header (when explicitly provided)
 
 ### Behavior
 

--- a/specs/05-producer-sequencing.md
+++ b/specs/05-producer-sequencing.md
@@ -204,15 +204,14 @@ The server tracks per `(stream, producerId)`:
 
 ### Cleanup
 
-For in-memory stores, the server SHOULD use a 7-day TTL on producer state,
-cleaning up stale entries on stream access. After state expiry, the producer
-is treated as new.
+The server SHOULD use a 7-day TTL on producer state, cleaning up stale
+entries on stream access. After state expiry, the producer is treated as new.
 
 ## Concurrency
 
 The server MUST serialize validation and append per `(stream, producerId)` pair.
-For in-memory storage, holding the per-stream write lock during both validation
-and append satisfies this requirement.
+Holding the per-stream write lock during both validation and append satisfies
+this requirement across all storage backends.
 
 ## Conformance
 

--- a/specs/CLAUDE.md
+++ b/specs/CLAUDE.md
@@ -22,7 +22,6 @@ Each spec document describes one discrete capability:
 - `01-stream-lifecycle.md` — create, delete, metadata (PUT, DELETE, HEAD)
 - `02-append-semantics.md` — appending data (POST)
 - `03-read-modes.md` — catch-up, long-poll, SSE (GET with modes)
-- `04-offset-semantics.md` — offset format, validation, resumption
 - `05-producer-sequencing.md` — idempotent producers, epoch fencing
 - `06-json-mode.md` — JSON array flattening
 - `07-caching-etag.md` — ETag generation, If-None-Match, Cache-Control

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -13,7 +13,7 @@ This file governs all code in `src/`. Violations should be caught by clippy or c
 ## Offset Invariants (Critical)
 
 - Offsets MUST be monotonically increasing within a stream.
-- Offset format: `{read_seq:016}_{byte_offset:016}` (zero-padded hex).
+- Offset format: `{read_seq:016x}_{byte_offset:016x}` (zero-padded hex).
 - Sentinels: `-1` (stream start), `now` (tail/live).
 - Lexicographic ordering equals temporal ordering.
 - Concurrent appends MUST be serialized per-stream to maintain monotonicity.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -45,7 +45,7 @@ scaffolding. The external conformance suite is the ultimate acceptance gate.
 
 ### External Conformance Suite (ultimate gate)
 
-- `@durable-streams/server-conformance-tests` on npm (~195 tests).
+- `@durable-streams/server-conformance-tests@0.2.2` on npm (239 tests).
 - These are the acceptance tests. If we pass all of these, we conform.
 - Run with `make conformance` or `npx @durable-streams/server-conformance-tests`.
 - Our Rust integration tests exist to provide faster feedback during development.
@@ -68,9 +68,9 @@ This ensures the same test expectations could validate any implementation of the
 ## Test Structure
 
 Each integration test file corresponds to a spec document:
-- `tests/stream_lifecycle.rs` → `specs/01-stream-lifecycle.md`
-- `tests/append_semantics.rs` → `specs/02-append-semantics.md`
-- `tests/read_modes.rs` → `specs/03-read-modes.md`
+- `tests/stream_creation.rs` → `specs/01-stream-lifecycle.md`
+- `tests/append_operations.rs` → `specs/02-append-semantics.md`
+- `tests/read_operations.rs` → `specs/03-read-modes.md`
 
 Within each file, test functions reference specific sections:
 ```rust
@@ -82,10 +82,10 @@ async fn test_create_stream() { ... }
 ## Test Helpers (`tests/common/mod.rs`)
 
 Common test utilities:
-- `spawn_test_server() -> (Server, u16)` — start server on random port
-- `test_client(port: u16) -> Client` — HTTP client with base URL
+- `spawn_test_server() -> (String, u16)` — start server on random port, returns `(base_url, port)`
+- `test_client() -> reqwest::Client` — HTTP client (no arguments)
+- `test_client_with_timeout(Duration) -> reqwest::Client` — HTTP client with custom timeout
 - `unique_stream_name() -> String` — generate unique stream names to avoid collisions
-- `shutdown_server(server: Server)` — clean shutdown
 
 Keep helpers focused. Don't build a framework. Just reduce duplication.
 


### PR DESCRIPTION
## Summary

Comprehensive documentation audit against current code and specs. Fixes across 19 files.

**Storage mode references (9 files):**
- Updated all docs that incorrectly described storage as memory-only
- Added "Storage backends" section to README with mode table and examples
- Added "Persistent storage" section to quickstart
- Updated spec 05-producer-sequencing to apply TTL/locking across all backends

**API documentation corrections (2 files):**
- PUT accepts a body with initial data (was: "body must be empty")
- Content-Type is optional on PUT, defaults to `application/octet-stream` (was: "required")
- Removed "non-empty body" and "missing Content-Type" from PUT 400 causes

**Configuration docs (2 files):**
- Server uses layered TOML + env vars (was: "configured entirely through environment variables")
- Invalid acid shard count returns an error (was: "falls back to 16")
- Documented `DS_LOG__RUST_LOG` env var

**CLAUDE.md / internal docs (3 files):**
- `tests/CLAUDE.md`: conformance count 195→239, fixed test file names and helper signatures
- `specs/CLAUDE.md`: removed reference to non-existent `04-offset-semantics.md`
- `src/CLAUDE.md`: fixed offset format string (missing hex `x` suffix)

**Cross-references and dates (3 files):**
- Fixed CI-001/CI-003 cross-reference anchors in json-mode.md and client-app.md
- Updated compatibility.md date to 2026-03-20

## Test plan

- [x] Docs-only change, no code affected
- [x] All changes verified against current source in src/config.rs, src/handlers/put.rs, tests/common/mod.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)