### PR TITLE
Remove .claude/skills symlinks, ignore .claude/

### DIFF
--- a/.claude/skills/coding-guidelines
+++ b/.claude/skills/coding-guidelines
@@ -1,1 +1,0 @@
-../../.agents/skills/coding-guidelines

--- a/.claude/skills/domain-web
+++ b/.claude/skills/domain-web
@@ -1,1 +1,0 @@
-../../.agents/skills/domain-web

--- a/.claude/skills/m01-ownership
+++ b/.claude/skills/m01-ownership
@@ -1,1 +1,0 @@
-../../.agents/skills/m01-ownership

--- a/.claude/skills/m02-resource
+++ b/.claude/skills/m02-resource
@@ -1,1 +1,0 @@
-../../.agents/skills/m02-resource

--- a/.claude/skills/m03-mutability
+++ b/.claude/skills/m03-mutability
@@ -1,1 +1,0 @@
-../../.agents/skills/m03-mutability

--- a/.claude/skills/m04-zero-cost
+++ b/.claude/skills/m04-zero-cost
@@ -1,1 +1,0 @@
-../../.agents/skills/m04-zero-cost

--- a/.claude/skills/m05-type-driven
+++ b/.claude/skills/m05-type-driven
@@ -1,1 +1,0 @@
-../../.agents/skills/m05-type-driven

--- a/.claude/skills/m06-error-handling
+++ b/.claude/skills/m06-error-handling
@@ -1,1 +1,0 @@
-../../.agents/skills/m06-error-handling

--- a/.claude/skills/m07-concurrency
+++ b/.claude/skills/m07-concurrency
@@ -1,1 +1,0 @@
-../../.agents/skills/m07-concurrency

--- a/.claude/skills/m09-domain
+++ b/.claude/skills/m09-domain
@@ -1,1 +1,0 @@
-../../.agents/skills/m09-domain

--- a/.claude/skills/m10-performance
+++ b/.claude/skills/m10-performance
@@ -1,1 +1,0 @@
-../../.agents/skills/m10-performance

--- a/.claude/skills/m11-ecosystem
+++ b/.claude/skills/m11-ecosystem
@@ -1,1 +1,0 @@
-../../.agents/skills/m11-ecosystem

--- a/.claude/skills/m12-lifecycle
+++ b/.claude/skills/m12-lifecycle
@@ -1,1 +1,0 @@
-../../.agents/skills/m12-lifecycle

--- a/.claude/skills/m13-domain-error
+++ b/.claude/skills/m13-domain-error
@@ -1,1 +1,0 @@
-../../.agents/skills/m13-domain-error

--- a/.claude/skills/m14-mental-model
+++ b/.claude/skills/m14-mental-model
@@ -1,1 +1,0 @@
-../../.agents/skills/m14-mental-model

--- a/.claude/skills/m15-anti-pattern
+++ b/.claude/skills/m15-anti-pattern
@@ -1,1 +1,0 @@
-../../.agents/skills/m15-anti-pattern

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
 .idea/
 *.iml
-.claude/settings.local.json
+.claude/
 e2e/node_modules/
 .dev/
 docs/book/book/


### PR DESCRIPTION
## Summary

- Remove 16 dangling symlinks from `.claude/skills/` (targets already live in `.agents/skills/`)
- Ignore entire `.claude/` directory instead of just `settings.local.json`

## Test plan

- [ ] No functional changes — skills files remain in `.agents/skills/`
- [ ] `.claude/` directory no longer tracked by git