### PR TITLE
Bump conformance test suite to 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pedantic = { level = "warn", priority = -1 }
 
 # Spec versions implemented:
 # - Spec SHA: a347312a47ae510a4a2e3ee7a121d6c8d7d74e50
-# - Conformance: 0.2.2
+# - Conformance: 0.2.3
 
 [dependencies]
 axum = { version = "0.8.8", features = ["macros"] }

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-integration:
 # Requires: node, npm
 # On first run, installs the conformance harness to /tmp/conformance-run
 CONFORMANCE_DIR := /tmp/conformance-run
-CONFORMANCE_VERSION := 0.2.2
+CONFORMANCE_VERSION := 0.2.3
 
 $(CONFORMANCE_DIR)/node_modules: $(CONFORMANCE_DIR)/package.json
 	cd $(CONFORMANCE_DIR) && npm install

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The latest benchmark matrix findings are in
 
 ## Conformance
 
-This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.2`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md).
+This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.3`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md).
 
 Run conformance tests locally:
 
@@ -91,7 +91,7 @@ DS_SERVER__LONG_POLL_TIMEOUT_SECS=2 DS_SERVER__SSE_RECONNECT_INTERVAL_SECS=5 car
 
 cd /tmp/conformance-run
 npm init -y
-npm install @durable-streams/server-conformance-tests@0.2.2
+npm install @durable-streams/server-conformance-tests@0.2.3
 cat > conformance.test.mjs << 'EOF'
 import { runConformanceTests } from "@durable-streams/server-conformance-tests";
 runConformanceTests({ baseUrl: process.env.CONFORMANCE_TEST_URL, longPollTimeoutMs: 2000 });

--- a/SPEC_VERSION.md
+++ b/SPEC_VERSION.md
@@ -17,7 +17,7 @@ and conformance test suite that this implementation targets.
 
 **Package:** `@durable-streams/server-conformance-tests`
 
-**Version:** `0.2.2`
+**Version:** `0.2.3`
 
 **NPM Registry:** https://www.npmjs.com/package/@durable-streams/server-conformance-tests
 

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -32,4 +32,4 @@ Together they implement the *durable sessions* pattern: real-time collaborative 
 
 ## Conformance
 
-This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.2`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md). All 239 conformance tests pass.
+This implementation targets full conformance with [`@durable-streams/server-conformance-tests@0.2.3`](https://www.npmjs.com/package/@durable-streams/server-conformance-tests) against spec commit [`a347312`](https://github.com/durable-streams/durable-streams/blob/a347312a47ae510a4a2e3ee7a121d6c8d7d74e50/PROTOCOL.md). All 239 conformance tests pass.

--- a/docs/book/src/project/governance.md
+++ b/docs/book/src/project/governance.md
@@ -20,7 +20,7 @@ This implementation strictly adheres to the durable streams protocol specificati
 The protocol spec is pinned by git commit SHA, not by branch. The conformance test suite is pinned by npm package version. See [`SPEC_VERSION.md`](https://github.com/thesampaton/durable-streams-rust-server/blob/trunk/SPEC_VERSION.md) for current pins:
 
 - **Spec SHA:** `a347312a47ae510a4a2e3ee7a121d6c8d7d74e50`
-- **Conformance:** `@durable-streams/server-conformance-tests@0.2.2`
+- **Conformance:** `@durable-streams/server-conformance-tests@0.2.3`
 
 ## Traceability
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,7 +16,7 @@ and any behaviour differences or breaking changes.
 
 **Spec SHA:** a347312a47ae510a4a2e3ee7a121d6c8d7d74e50
 
-**Conformance Version:** 0.2.2
+**Conformance Version:** 0.2.3
 
 **Status:** Fully conformant. All 239 conformance tests pass.
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -45,7 +45,7 @@ scaffolding. The external conformance suite is the ultimate acceptance gate.
 
 ### External Conformance Suite (ultimate gate)
 
-- `@durable-streams/server-conformance-tests@0.2.2` on npm (239 tests).
+- `@durable-streams/server-conformance-tests@0.2.3` on npm (239 tests).
 - These are the acceptance tests. If we pass all of these, we conform.
 - Run with `make conformance` or `npx @durable-streams/server-conformance-tests`.
 - Our Rust integration tests exist to provide faster feedback during development.


### PR DESCRIPTION
## Summary

- Update `@durable-streams/server-conformance-tests` from 0.2.2 to 0.2.3 across all config and documentation
- The 0.2.3 release only bumps the client dependency (fix for null body on HEAD responses); the test suite itself is unchanged
- All 239 conformance tests pass, spec SHA unchanged

## Test plan

- [x] `make conformance` — 239/239 passing
- [x] `cargo test` — all unit + integration tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)